### PR TITLE
fixed error in options_to_images

### DIFF
--- a/detection/run_tf_detector_batch.py
+++ b/detection/run_tf_detector_batch.py
@@ -365,7 +365,7 @@ def options_to_images(options):
         
         assert os.path.isfile(options.imageFile)
         
-        if is_image_file(options.imagefile):
+        if is_image_file(options.imageFile):
             imageFileNames = [options.imageFile]
         else:
             with open(options.imageFile) as f:


### PR DESCRIPTION
fixed error that resulted in calling run_tf_detector_batch.py with a text list of images files to fail.