### PR TITLE
Use multiprocessing lock in batch detection api

### DIFF
--- a/api/batch_processing/api_core/orchestrator_api/runserver.py
+++ b/api/batch_processing/api_core/orchestrator_api/runserver.py
@@ -4,10 +4,10 @@
 from datetime import datetime
 import json
 import math
+import multiprocessing
 import os
 from random import shuffle
 import string
-import threading
 import time
 from typing import Any, Dict, Mapping
 import urllib.parse
@@ -67,7 +67,12 @@ internal_datastore = {
 print('Internal storage container {} in account {} is set up.'.format(
     internal_container, storage_account_name))
 
-task_status_lock = threading.Lock()
+# We use multiprocessing.Lock which works everywhere a threading.Lock works,
+# i.e., even in single-process, multi-threaded code. However, this lock is only
+# effective if the lock is actually created before worker processes are forked
+# and therefore shared. Thus, we require --preload flag when running gunicorn.
+# See https://stackoverflow.com/q/18213619.
+task_status_lock = multiprocessing.Lock()
 
 
 def update_task_status(task_manager: Any, request_id: str,

--- a/api/batch_processing/api_core/supervisord.conf
+++ b/api/batch_processing/api_core/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:gunicorn]
 directory=/app/orchestrator_api/
-command=gunicorn -b 0.0.0.0:1212 --workers 4 runserver:app
+command=gunicorn -b 0.0.0.0:1212 --workers 4 --preload runserver:app
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stdout


### PR DESCRIPTION
Continues off of the work from https://github.com/microsoft/CameraTraps/pull/205 which didn't completely resolve the thread-safety issue because the lock was not shared by the gunicorn worker processes. This pull request should hopefully fix the issue by:

1) using a `multiprocessing.Lock` instead of a `threading.Lock`
2) sharing the lock among the worker processes by forking the Flask app after the lock has already been created, via the `--preload` flag for gunicorn