### PR TITLE
Add inference class for the YOLOv5 model. Refactor run_tf_detector.py.

### DIFF
--- a/api/batch_processing/api_core/batch_service/score.py
+++ b/api/batch_processing/api_core/batch_service/score.py
@@ -111,8 +111,8 @@ def load_image(input_file: Union[str, BytesIO]) -> Image.Image:
     return image
 
 
-#%% TFDetector class, an unmodified *copy* of the class in detection/run_tf_detector.py,
-# so we do not have to import the packages required by run_tf_detector.py
+#%% TFDetector class, an unmodified *copy* of the class in detection/tf_detector.py,
+# so we do not have to import the packages required by run_detector.py
 
 class TFDetector:
     """

--- a/api/batch_processing/api_core/server_api_config.py
+++ b/api/batch_processing/api_core/server_api_config.py
@@ -56,7 +56,7 @@ MD_VERSIONS_TO_REL_PATH = {
 DEFAULT_MD_VERSION = '4.1'
 assert DEFAULT_MD_VERSION in MD_VERSIONS_TO_REL_PATH
 
-# copied from TFDetector class in detection/run_tf_detector.py
+# copied from TFDetector class in detection/run_detector.py
 DETECTOR_LABEL_MAP = {
     '1': 'animal',
     '2': 'person',

--- a/demo/run_tf_detector.py
+++ b/demo/run_tf_detector.py
@@ -1,6 +1,6 @@
 ######
 #
-# run_tf_detector.py
+# run_detector.py
 #
 # Functions to load a TensorFlow detection model, run inference,
 # and render bounding boxes on images.

--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -1,0 +1,292 @@
+"""
+Module to run MegaDetector v5, a PyTorch YOLOv5 (Ultralytics) animal detection model,
+on images.
+
+Dependencies:
+- PyTorch
+- opencv-python>=4.1.2
+- numpy
+
+"""
+
+#%% Imports
+
+import time
+
+import cv2
+import torch
+import torchvision
+import numpy as np
+
+from detection.run_detector import CONF_DIGITS, COORD_DIGITS, FAILURE_INFER
+import ct_utils
+
+
+#%% Classes
+
+class PTDetector:
+
+    IMAGE_SIZE = 1280  # image size used in training
+    STRIDE = 64
+
+
+    def __init__(self, torchscript_model_path):
+        self.device = torch.device('cuda:0') if torch.cuda.is_available() else 'cpu'
+        self.model = PTDetector.__load_model(torchscript_model_path)
+
+
+    @staticmethod
+    def __load_model(torchscript_model_path):
+        extra_files = {'config.txt': ''}  # model metadata
+        model = torch.jit.load(torchscript_model_path, _extra_files=extra_files)
+        return model
+
+
+    def generate_detections_one_image(self, img_original, image_id, detection_threshold):
+        """Apply the detector to an image.
+
+        Args:
+            img_original: the PIL Image object with EXIF rotation taken into account
+            image_id: a path to identify the image; will be in the "file" field of the output object
+            detection_threshold: confidence above which to include the detection proposal
+
+        Returns:
+        A dict with the following fields, see the 'images' key in https://github.com/microsoft/CameraTraps/tree/master/api/batch_processing#batch-processing-api-output-format
+            - 'file' (always present)
+            - 'max_detection_conf'
+            - 'detections', which is a list of detection objects containing keys 'category', 'conf' and 'bbox'
+            - 'failure'
+        """
+
+        result = {
+            'file': image_id
+        }
+        detections = []
+        max_conf = 0.0
+
+        try:
+            img_original = np.asarray(img_original)
+
+            # padded resize
+            img = letterbox(img_original, new_shape=PTDetector.IMAGE_SIZE,
+                                 stride=PTDetector.STRIDE, auto=False)[0] # JIT requires auto=False
+
+            img = img.transpose((2, 0, 1))  # HWC to CHW; PIL Image is RGB already
+            img = np.ascontiguousarray(img)
+            img = torch.from_numpy(img).to(self.device)
+            img = img.float()
+            img /= 255
+
+            if len(img.shape) == 3:  # always true here, TO REFACTOR
+                img = torch.unsqueeze(img, 0)
+
+            pred: list = self.model(img)[0]
+
+            # NMS
+            pred = non_max_suppression(prediction=pred, conf_thres=detection_threshold)
+
+            # format detections/bounding boxes
+            gn = torch.tensor(img_original.shape)[[1, 0, 1, 0]]  # normalization gain whwh
+
+            for det in pred:
+                if len(det):
+                    # Rescale boxes from img_size to im0 size
+                    det[:, :4] = scale_coords(img.shape[2:], det[:, :4], img_original.shape).round()
+
+                    for *xyxy, conf, cls in reversed(det):
+                        # normalized center-x, center-y, width and height
+                        xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()
+
+                        api_box = ct_utils.convert_yolo_to_xywh(xywh)
+
+                        conf = ct_utils.truncate_float(conf.tolist(), precision=CONF_DIGITS)
+
+                        # MegaDetector output format's categories start at 1, but this model's start at 0
+                        cls = int(cls.tolist()) + 1
+                        if cls not in (1, 2, 3):
+                            raise KeyError(f'{cls} is not a valid class.')
+
+                        detections.append({
+                            'category': str(cls),
+                            'conf': conf,
+                            'bbox': ct_utils.truncate_float_array(api_box, precision=COORD_DIGITS)
+                        })
+                        max_conf = max(max_conf, conf)
+
+        except Exception as e:
+            result['failure'] = FAILURE_INFER
+            print('PTDetector: image {} failed during inference: {}'.format(image_id, str(e)))
+
+        result['max_detection_conf'] = max_conf
+        result['detections'] = detections
+
+        return result
+
+
+#&& Helper functions from ultralytics/yolov5: YOLOv5 🚀 in PyTorch > ONNX > …
+
+def letterbox(im, new_shape=(640, 640), color=(114, 114, 114), auto=True, scaleFill=False, scaleup=True, stride=32):
+    # Resize and pad image while meeting stride-multiple constraints
+    shape = im.shape[:2]  # current shape [height, width]
+    if isinstance(new_shape, int):
+        new_shape = (new_shape, new_shape)
+
+    # Scale ratio (new / old)
+    r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+    if not scaleup:  # only scale down, do not scale up (for better val mAP)
+        r = min(r, 1.0)
+
+    # Compute padding
+    ratio = r, r  # width, height ratios
+    new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
+    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]  # wh padding
+    if auto:  # minimum rectangle
+        dw, dh = np.mod(dw, stride), np.mod(dh, stride)  # wh padding
+    elif scaleFill:  # stretch
+        dw, dh = 0.0, 0.0
+        new_unpad = (new_shape[1], new_shape[0])
+        ratio = new_shape[1] / shape[1], new_shape[0] / shape[0]  # width, height ratios
+
+    dw /= 2  # divide padding into 2 sides
+    dh /= 2
+
+    if shape[::-1] != new_unpad:  # resize
+        im = cv2.resize(im, new_unpad, interpolation=cv2.INTER_LINEAR)
+    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
+    im = cv2.copyMakeBorder(im, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)  # add border
+    return im, ratio, (dw, dh)
+
+
+def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.45, classes=None, agnostic=False, multi_label=False,
+                        labels=(), max_det=300):
+    """Runs Non-Maximum Suppression (NMS) on inference results
+
+    Returns:
+         list of detections, on (n,6) tensor per image [xyxy, conf, cls]
+    """
+
+    nc = prediction.shape[2] - 5  # number of classes
+    xc = prediction[..., 4] > conf_thres  # candidates
+
+    # Checks
+    assert 0 <= conf_thres <= 1, f'Invalid Confidence threshold {conf_thres}, valid values are between 0.0 and 1.0'
+    assert 0 <= iou_thres <= 1, f'Invalid IoU {iou_thres}, valid values are between 0.0 and 1.0'
+
+    # Settings
+    min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
+    max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
+    time_limit = 10.0  # seconds to quit after
+    redundant = True  # require redundant detections
+    multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
+
+    t = time.time()
+    output = [torch.zeros((0, 6), device=prediction.device)] * prediction.shape[0]
+    for xi, x in enumerate(prediction):  # image index, image inference
+        # Apply constraints
+        # x[((x[..., 2:4] < min_wh) | (x[..., 2:4] > max_wh)).any(1), 4] = 0  # width-height
+        x = x[xc[xi]]  # confidence
+
+        # Cat apriori labels if autolabelling
+        if labels and len(labels[xi]):
+            l = labels[xi]
+            v = torch.zeros((len(l), nc + 5), device=x.device)
+            v[:, :4] = l[:, 1:5]  # box
+            v[:, 4] = 1.0  # conf
+            v[range(len(l)), l[:, 0].long() + 5] = 1.0  # cls
+            x = torch.cat((x, v), 0)
+
+        # If none remain process next image
+        if not x.shape[0]:
+            continue
+
+        # Compute conf
+        x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
+
+        # Box (center x, center y, width, height) to (x1, y1, x2, y2)
+        box = xywh2xyxy(x[:, :4])
+
+        # Detections matrix nx6 (xyxy, conf, cls)
+        if multi_label:
+            i, j = (x[:, 5:] > conf_thres).nonzero(as_tuple=False).T
+            x = torch.cat((box[i], x[i, j + 5, None], j[:, None].float()), 1)
+        else:  # best class only
+            conf, j = x[:, 5:].max(1, keepdim=True)
+            x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
+
+        # Filter by class
+        if classes is not None:
+            x = x[(x[:, 5:6] == torch.tensor(classes, device=x.device)).any(1)]
+
+        # Apply finite constraint
+        # if not torch.isfinite(x).all():
+        #     x = x[torch.isfinite(x).all(1)]
+
+        # Check shape
+        n = x.shape[0]  # number of boxes
+        if not n:  # no boxes
+            continue
+        elif n > max_nms:  # excess boxes
+            x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence
+
+        # Batched NMS
+        c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
+        boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
+        i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
+        if i.shape[0] > max_det:  # limit detections
+            i = i[:max_det]
+
+        output[xi] = x[i]
+        if (time.time() - t) > time_limit:
+            print(f'WARNING: NMS time limit {time_limit}s exceeded')
+            break  # time limit exceeded
+
+    return output
+
+
+def xyxy2xywh(x):
+    # Convert nx4 boxes from [x1, y1, x2, y2] to [x, y, w, h] where xy1=top-left, xy2=bottom-right
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
+    y[:, 0] = (x[:, 0] + x[:, 2]) / 2  # x center
+    y[:, 1] = (x[:, 1] + x[:, 3]) / 2  # y center
+    y[:, 2] = x[:, 2] - x[:, 0]  # width
+    y[:, 3] = x[:, 3] - x[:, 1]  # height
+    return y
+
+
+def xywh2xyxy(x):
+    # Convert nx4 boxes from [x, y, w, h] to [x1, y1, x2, y2] where xy1=top-left, xy2=bottom-right
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
+    y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
+    y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
+    y[:, 2] = x[:, 0] + x[:, 2] / 2  # bottom right x
+    y[:, 3] = x[:, 1] + x[:, 3] / 2  # bottom right y
+    return y
+
+
+def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):
+    # Rescale coords (xyxy) from img1_shape to img0_shape
+    if ratio_pad is None:  # calculate from img0_shape
+        gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
+        pad = (img1_shape[1] - img0_shape[1] * gain) / 2, (img1_shape[0] - img0_shape[0] * gain) / 2  # wh padding
+    else:
+        gain = ratio_pad[0][0]
+        pad = ratio_pad[1]
+
+    coords[:, [0, 2]] -= pad[0]  # x padding
+    coords[:, [1, 3]] -= pad[1]  # y padding
+    coords[:, :4] /= gain
+    clip_coords(coords, img0_shape)
+    return coords
+
+
+def clip_coords(boxes, shape):
+    # Clip bounding xyxy bounding boxes to image shape (height, width)
+    if isinstance(boxes, torch.Tensor):  # faster individually
+        boxes[:, 0].clamp_(0, shape[1])  # x1
+        boxes[:, 1].clamp_(0, shape[0])  # y1
+        boxes[:, 2].clamp_(0, shape[1])  # x2
+        boxes[:, 3].clamp_(0, shape[0])  # y2
+    else:  # np.array (faster grouped)
+        boxes[:, [0, 2]] = boxes[:, [0, 2]].clip(0, shape[1])  # x1, x2
+        boxes[:, [1, 3]] = boxes[:, [1, 3]].clip(0, shape[0])  # y1, y2

--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -12,6 +12,7 @@ Dependencies:
 #%% Imports
 
 import time
+import sys
 
 import cv2
 import torch
@@ -30,13 +31,30 @@ class PTDetector:
     STRIDE = 64
 
 
-    def __init__(self, torchscript_model_path):
+    def __init__(self, model_path):
         self.device = torch.device('cuda:0') if torch.cuda.is_available() else 'cpu'
-        self.model = PTDetector.__load_model(torchscript_model_path)
+        self.is_pt = False if model_path.endswith('.torchscript.pt') else True
+        if self.is_pt:
+            try:
+                from models.yolo import Model
+            except ModuleNotFoundError:
+                print('The yolov5 module is not found.')
+                sys.exit(1)
+            print('Using the PyTorch checkpoint to perform inference.')
+            # deserialization in torch.load() will error if models.yolo.Model is not imported
+            self.model = PTDetector.__load_model(model_path, self.device)
+        else:
+            self.model = PTDetector.__load_torchscript_model(model_path)
+
+    @staticmethod
+    def __load_model(model_pt_path, device):
+        checkpoint = torch.load(model_pt_path, map_location=device)
+        model = checkpoint['model'].float().fuse().eval()  # FP32 model
+        return model
 
 
     @staticmethod
-    def __load_model(torchscript_model_path):
+    def __load_torchscript_model(torchscript_model_path):
         extra_files = {'config.txt': ''}  # model metadata
         model = torch.jit.load(torchscript_model_path, _extra_files=extra_files)
         return model
@@ -69,7 +87,7 @@ class PTDetector:
 
             # padded resize
             img = letterbox(img_original, new_shape=PTDetector.IMAGE_SIZE,
-                                 stride=PTDetector.STRIDE, auto=False)[0] # JIT requires auto=False
+                                 stride=PTDetector.STRIDE, auto=self.is_pt)[0] # JIT requires auto=False
 
             img = img.transpose((2, 0, 1))  # HWC to CHW; PIL Image is RGB already
             img = np.ascontiguousarray(img)

--- a/detection/run_detector.py
+++ b/detection/run_detector.py
@@ -1,8 +1,7 @@
 r"""
-Module to run a TensorFlow animal detection model on images.
+Module to run an animal detection model on images.
 
-The class TFDetector contains functions to load a TensorFlow detection model and
-run inference. The main function in this script also renders the predicted
+The main function in this script also renders the predicted
 bounding boxes on images and saves the resulting images (with bounding boxes).
 
 This script is not a good way to process lots of images (tens of thousands,
@@ -49,10 +48,8 @@ import time
 import warnings
 
 import humanfriendly
-import numpy as np
 from tqdm import tqdm
 
-from ct_utils import truncate_float
 import visualization.visualization_utils as viz_utils
 
 # ignoring all "PIL cannot read EXIF metainfo for the images" warnings
@@ -67,10 +64,24 @@ warnings.filterwarnings('ignore', category=FutureWarning)
 # Useful hack to force CPU inference
 # os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 
-import tensorflow.compat.v1 as tf
 
-print('TensorFlow version:', tf.__version__)
-print('Is GPU available? tf.test.is_gpu_available:', tf.test.is_gpu_available())
+# An enumeration of failure reasons
+FAILURE_INFER = 'Failure inference'
+FAILURE_IMAGE_OPEN = 'Failure image access'
+
+DEFAULT_RENDERING_CONFIDENCE_THRESHOLD = 0.85  # to render bounding boxes
+DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD = 0.1  # to include in the output json file
+
+# Number of decimal places to round to for confidence and bbox coordinates
+CONF_DIGITS = 3
+COORD_DIGITS = 4
+
+# Label mapping for the MegaDetector
+DEFAULT_DETECTOR_LABEL_MAP = {
+    '1': 'animal',
+    '2': 'person',
+    '3': 'vehicle'  # available in megadetector v4+
+}
 
 
 #%% Classes
@@ -114,179 +125,10 @@ class ImagePathUtils:
         return image_strings
 
 
-class TFDetector:
-    """
-    A detector model loaded at the time of initialization. It is intended to be used with
-    the MegaDetector (TF). The inference batch size is set to 1; code needs to be modified
-    to support larger batch sizes, including resizing appropriately.
-    """
-
-    # Number of decimal places to round to for confidence and bbox coordinates
-    CONF_DIGITS = 3
-    COORD_DIGITS = 4
-
-    # MegaDetector was trained with batch size of 1, and the resizing function is a part
-    # of the inference graph
-    BATCH_SIZE = 1
-
-    # An enumeration of failure reasons
-    FAILURE_TF_INFER = 'Failure TF inference'
-    FAILURE_IMAGE_OPEN = 'Failure image access'
-
-    DEFAULT_RENDERING_CONFIDENCE_THRESHOLD = 0.85  # to render bounding boxes
-    DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD = 0.1  # to include in the output json file
-
-    DEFAULT_DETECTOR_LABEL_MAP = {
-        '1': 'animal',
-        '2': 'person',
-        '3': 'vehicle'  # available in megadetector v4+
-    }
-
-    NUM_DETECTOR_CATEGORIES = 4  # animal, person, group, vehicle - for color assignment
-
-    def __init__(self, model_path):
-        """Loads model from model_path and starts a tf.Session with this graph. Obtains
-        input and output tensor handles."""
-        detection_graph = TFDetector.__load_model(model_path)
-        self.tf_session = tf.Session(graph=detection_graph)
-
-        self.image_tensor = detection_graph.get_tensor_by_name('image_tensor:0')
-        self.box_tensor = detection_graph.get_tensor_by_name('detection_boxes:0')
-        self.score_tensor = detection_graph.get_tensor_by_name('detection_scores:0')
-        self.class_tensor = detection_graph.get_tensor_by_name('detection_classes:0')
-
-    @staticmethod
-    def round_and_make_float(d, precision=4):
-        return truncate_float(float(d), precision=precision)
-
-    @staticmethod
-    def __convert_coords(tf_coords):
-        """Converts coordinates from the model's output format [y1, x1, y2, x2] to the
-        format used by our API and MegaDB: [x1, y1, width, height]. All coordinates
-        (including model outputs) are normalized in the range [0, 1].
-
-        Args:
-            tf_coords: np.array of predicted bounding box coordinates from the TF detector,
-                has format [y1, x1, y2, x2]
-
-        Returns: list of Python float, predicted bounding box coordinates [x1, y1, width, height]
-        """
-        # change from [y1, x1, y2, x2] to [x1, y1, width, height]
-        width = tf_coords[3] - tf_coords[1]
-        height = tf_coords[2] - tf_coords[0]
-
-        new = [tf_coords[1], tf_coords[0], width, height]  # must be a list instead of np.array
-
-        # convert numpy floats to Python floats
-        for i, d in enumerate(new):
-            new[i] = TFDetector.round_and_make_float(d, precision=TFDetector.COORD_DIGITS)
-        return new
-
-    @staticmethod
-    def convert_to_tf_coords(array):
-        """From [x1, y1, width, height] to [y1, x1, y2, x2], where x1 is x_min, x2 is x_max
-
-        This is an extraneous step as the model outputs [y1, x1, y2, x2] but were converted to the API
-        output format - only to keep the interface of the sync API.
-        """
-        x1 = array[0]
-        y1 = array[1]
-        width = array[2]
-        height = array[3]
-        x2 = x1 + width
-        y2 = y1 + height
-        return [y1, x1, y2, x2]
-
-    @staticmethod
-    def __load_model(model_path):
-        """Loads a detection model (i.e., create a graph) from a .pb file.
-
-        Args:
-            model_path: .pb file of the model.
-
-        Returns: the loaded graph.
-        """
-        print('TFDetector: Loading graph...')
-        detection_graph = tf.Graph()
-        with detection_graph.as_default():
-            od_graph_def = tf.GraphDef()
-            with tf.gfile.GFile(model_path, 'rb') as fid:
-                serialized_graph = fid.read()
-                od_graph_def.ParseFromString(serialized_graph)
-                tf.import_graph_def(od_graph_def, name='')
-        print('TFDetector: Detection graph loaded.')
-
-        return detection_graph
-
-    def _generate_detections_one_image(self, image):
-        np_im = np.asarray(image, np.uint8)
-        im_w_batch_dim = np.expand_dims(np_im, axis=0)
-
-        # need to change the above line to the following if supporting a batch size > 1 and resizing to the same size
-        # np_images = [np.asarray(image, np.uint8) for image in images]
-        # images_stacked = np.stack(np_images, axis=0) if len(images) > 1 else np.expand_dims(np_images[0], axis=0)
-
-        # performs inference
-        (box_tensor_out, score_tensor_out, class_tensor_out) = self.tf_session.run(
-            [self.box_tensor, self.score_tensor, self.class_tensor],
-            feed_dict={self.image_tensor: im_w_batch_dim})
-
-        return box_tensor_out, score_tensor_out, class_tensor_out
-
-    def generate_detections_one_image(self, image, image_id,
-                                      detection_threshold=DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD):
-        """Apply the detector to an image.
-
-        Args:
-            image: the PIL Image object
-            image_id: a path to identify the image; will be in the "file" field of the output object
-            detection_threshold: confidence above which to include the detection proposal
-
-        Returns:
-        A dict with the following fields, see the 'images' key in https://github.com/microsoft/CameraTraps/tree/master/api/batch_processing#batch-processing-api-output-format
-            - 'file' (always present)
-            - 'max_detection_conf'
-            - 'detections', which is a list of detection objects containing keys 'category', 'conf' and 'bbox'
-            - 'failure'
-        """
-        result = {
-            'file': image_id
-        }
-        try:
-            b_box, b_score, b_class = self._generate_detections_one_image(image)
-
-            # our batch size is 1; need to loop the batch dim if supporting batch size > 1
-            boxes, scores, classes = b_box[0], b_score[0], b_class[0]
-
-            detections_cur_image = []  # will be empty for an image with no confident detections
-            max_detection_conf = 0.0
-            for b, s, c in zip(boxes, scores, classes):
-                if s > detection_threshold:
-                    detection_entry = {
-                        'category': str(int(c)),  # use string type for the numerical class label, not int
-                        'conf': truncate_float(float(s),  # cast to float for json serialization
-                                               precision=TFDetector.CONF_DIGITS),
-                        'bbox': TFDetector.__convert_coords(b)
-                    }
-                    detections_cur_image.append(detection_entry)
-                    if s > max_detection_conf:
-                        max_detection_conf = s
-
-            result['max_detection_conf'] = truncate_float(float(max_detection_conf),
-                                                          precision=TFDetector.CONF_DIGITS)
-            result['detections'] = detections_cur_image
-
-        except Exception as e:
-            result['failure'] = TFDetector.FAILURE_TF_INFER
-            print('TFDetector: image {} failed during inference: {}'.format(image_id, str(e)))
-
-        return result
-
-
 #%% Main function
 
 def load_and_run_detector(model_file, image_file_names, output_dir,
-                          render_confidence_threshold=TFDetector.DEFAULT_RENDERING_CONFIDENCE_THRESHOLD,
+                          render_confidence_threshold=DEFAULT_RENDERING_CONFIDENCE_THRESHOLD,
                           crop_images=False):
     """Load and run detector on target images, and visualize the results."""
     if len(image_file_names) == 0:
@@ -294,7 +136,12 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
         return
 
     start_time = time.time()
-    tf_detector = TFDetector(model_file)
+    if model_file.endswith('.pb'):
+        from detection.tf_detector import TFDetector
+        detector = TFDetector(model_file)
+    elif model_file.endswith('.torchscript.pt'):
+        from detection.pytorch_detector import PTDetector
+        detector = PTDetector(model_file)
     elapsed = time.time() - start_time
     print('Loaded model in {}'.format(humanfriendly.format_timespan(elapsed)))
 
@@ -364,7 +211,7 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
             print('Image {} cannot be loaded. Exception: {}'.format(im_file, e))
             result = {
                 'file': im_file,
-                'failure': TFDetector.FAILURE_IMAGE_OPEN
+                'failure': FAILURE_IMAGE_OPEN
             }
             detection_results.append(result)
             continue
@@ -372,7 +219,8 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
         try:
             start_time = time.time()
 
-            result = tf_detector.generate_detections_one_image(image, im_file)
+            result = detector.generate_detections_one_image(image, im_file,
+                                                            detection_threshold=DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD)
             detection_results.append(result)
 
             elapsed = time.time() - start_time
@@ -395,7 +243,7 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
 
                 # image is modified in place
                 viz_utils.render_detection_bounding_boxes(result['detections'], image,
-                                                          label_map=TFDetector.DEFAULT_DETECTOR_LABEL_MAP,
+                                                          label_map=DEFAULT_DETECTOR_LABEL_MAP,
                                                           confidence_threshold=render_confidence_threshold)
                 output_full_path = input_file_to_detection_file(im_file)
                 image.save(output_full_path)
@@ -426,7 +274,7 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
 def main():
 
     parser = argparse.ArgumentParser(
-        description='Module to run a TF animal detection model on images')
+        description='Module to run an animal detection model on images')
     parser.add_argument(
         'detector_file',
         help='Path to .pb TensorFlow detector model file')
@@ -447,7 +295,7 @@ def main():
     parser.add_argument(
         '--threshold',
         type=float,
-        default=TFDetector.DEFAULT_RENDERING_CONFIDENCE_THRESHOLD,
+        default=DEFAULT_RENDERING_CONFIDENCE_THRESHOLD,
         help=('Confidence threshold between 0 and 1.0; only render boxes above this confidence'
               ' (but only boxes above 0.1 confidence will be considered at all)'))
     parser.add_argument(

--- a/detection/run_detector.py
+++ b/detection/run_detector.py
@@ -139,7 +139,7 @@ def load_and_run_detector(model_file, image_file_names, output_dir,
     if model_file.endswith('.pb'):
         from detection.tf_detector import TFDetector
         detector = TFDetector(model_file)
-    elif model_file.endswith('.torchscript.pt'):
+    elif model_file.endswith('.pt'):
         from detection.pytorch_detector import PTDetector
         detector = PTDetector(model_file)
     elapsed = time.time() - start_time

--- a/detection/run_tf_detector_batch.py
+++ b/detection/run_tf_detector_batch.py
@@ -63,7 +63,7 @@ force_cpu = False
 if force_cpu:
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 
-from detection.run_tf_detector import ImagePathUtils, TFDetector
+from detection.run_detector import ImagePathUtils, TFDetector
 import visualization.visualization_utils as viz_utils
 
 # Numpy FutureWarnings from tensorflow import
@@ -159,7 +159,7 @@ def run_detector_with_image_queue(image_files,model_file,confidence_threshold):
  
     # TODO
     #
-    # The queue system is a little more elegant if we start one thread for reading an one
+    # The queue system is a little more elegant if we start one thread for reading and one
     # for processing, and this works fine on Windows, but because we import TF at module load,
     # CUDA will only work in the main process, so currently the consumer function runs here.
     #

--- a/detection/tf_detector.py
+++ b/detection/tf_detector.py
@@ -1,0 +1,163 @@
+"""
+Module containing the class TFDetector for loading a TensorFlow detection model and
+running inference.
+"""
+
+import numpy as np
+
+from detection.run_detector import CONF_DIGITS, COORD_DIGITS, FAILURE_INFER
+from ct_utils import truncate_float
+
+import tensorflow.compat.v1 as tf
+
+print('TensorFlow version:', tf.__version__)
+print('Is GPU available? tf.test.is_gpu_available:', tf.test.is_gpu_available())
+
+
+class TFDetector:
+    """
+    A detector model loaded at the time of initialization. It is intended to be used with
+    the MegaDetector (TF). The inference batch size is set to 1; code needs to be modified
+    to support larger batch sizes, including resizing appropriately.
+    """
+    # MegaDetector was trained with batch size of 1, and the resizing function is a part
+    # of the inference graph
+    BATCH_SIZE = 1
+
+
+    def __init__(self, model_path):
+        """Loads model from model_path and starts a tf.Session with this graph. Obtains
+        input and output tensor handles."""
+        detection_graph = TFDetector.__load_model(model_path)
+        self.tf_session = tf.Session(graph=detection_graph)
+
+        self.image_tensor = detection_graph.get_tensor_by_name('image_tensor:0')
+        self.box_tensor = detection_graph.get_tensor_by_name('detection_boxes:0')
+        self.score_tensor = detection_graph.get_tensor_by_name('detection_scores:0')
+        self.class_tensor = detection_graph.get_tensor_by_name('detection_classes:0')
+
+    @staticmethod
+    def round_and_make_float(d, precision=4):
+        return truncate_float(float(d), precision=precision)
+
+    @staticmethod
+    def __convert_coords(tf_coords):
+        """Converts coordinates from the model's output format [y1, x1, y2, x2] to the
+        format used by our API and MegaDB: [x1, y1, width, height]. All coordinates
+        (including model outputs) are normalized in the range [0, 1].
+
+        Args:
+            tf_coords: np.array of predicted bounding box coordinates from the TF detector,
+                has format [y1, x1, y2, x2]
+
+        Returns: list of Python float, predicted bounding box coordinates [x1, y1, width, height]
+        """
+        # change from [y1, x1, y2, x2] to [x1, y1, width, height]
+        width = tf_coords[3] - tf_coords[1]
+        height = tf_coords[2] - tf_coords[0]
+
+        new = [tf_coords[1], tf_coords[0], width, height]  # must be a list instead of np.array
+
+        # convert numpy floats to Python floats
+        for i, d in enumerate(new):
+            new[i] = TFDetector.round_and_make_float(d, precision=COORD_DIGITS)
+        return new
+
+    @staticmethod
+    def convert_to_tf_coords(array):
+        """From [x1, y1, width, height] to [y1, x1, y2, x2], where x1 is x_min, x2 is x_max
+
+        This is an extraneous step as the model outputs [y1, x1, y2, x2] but were converted to the API
+        output format - only to keep the interface of the sync API.
+        """
+        x1 = array[0]
+        y1 = array[1]
+        width = array[2]
+        height = array[3]
+        x2 = x1 + width
+        y2 = y1 + height
+        return [y1, x1, y2, x2]
+
+    @staticmethod
+    def __load_model(model_path):
+        """Loads a detection model (i.e., create a graph) from a .pb file.
+
+        Args:
+            model_path: .pb file of the model.
+
+        Returns: the loaded graph.
+        """
+        print('TFDetector: Loading graph...')
+        detection_graph = tf.Graph()
+        with detection_graph.as_default():
+            od_graph_def = tf.GraphDef()
+            with tf.gfile.GFile(model_path, 'rb') as fid:
+                serialized_graph = fid.read()
+                od_graph_def.ParseFromString(serialized_graph)
+                tf.import_graph_def(od_graph_def, name='')
+        print('TFDetector: Detection graph loaded.')
+
+        return detection_graph
+
+    def _generate_detections_one_image(self, image):
+        np_im = np.asarray(image, np.uint8)
+        im_w_batch_dim = np.expand_dims(np_im, axis=0)
+
+        # need to change the above line to the following if supporting a batch size > 1 and resizing to the same size
+        # np_images = [np.asarray(image, np.uint8) for image in images]
+        # images_stacked = np.stack(np_images, axis=0) if len(images) > 1 else np.expand_dims(np_images[0], axis=0)
+
+        # performs inference
+        (box_tensor_out, score_tensor_out, class_tensor_out) = self.tf_session.run(
+            [self.box_tensor, self.score_tensor, self.class_tensor],
+            feed_dict={self.image_tensor: im_w_batch_dim})
+
+        return box_tensor_out, score_tensor_out, class_tensor_out
+
+    def generate_detections_one_image(self, image, image_id, detection_threshold):
+        """Apply the detector to an image.
+
+        Args:
+            image: the PIL Image object
+            image_id: a path to identify the image; will be in the "file" field of the output object
+            detection_threshold: confidence above which to include the detection proposal
+
+        Returns:
+        A dict with the following fields, see the 'images' key in https://github.com/microsoft/CameraTraps/tree/master/api/batch_processing#batch-processing-api-output-format
+            - 'file' (always present)
+            - 'max_detection_conf'
+            - 'detections', which is a list of detection objects containing keys 'category', 'conf' and 'bbox'
+            - 'failure'
+        """
+        result = {
+            'file': image_id
+        }
+        try:
+            b_box, b_score, b_class = self._generate_detections_one_image(image)
+
+            # our batch size is 1; need to loop the batch dim if supporting batch size > 1
+            boxes, scores, classes = b_box[0], b_score[0], b_class[0]
+
+            detections_cur_image = []  # will be empty for an image with no confident detections
+            max_detection_conf = 0.0
+            for b, s, c in zip(boxes, scores, classes):
+                if s > detection_threshold:
+                    detection_entry = {
+                        'category': str(int(c)),  # use string type for the numerical class label, not int
+                        'conf': truncate_float(float(s),  # cast to float for json serialization
+                                               precision=CONF_DIGITS),
+                        'bbox': TFDetector.__convert_coords(b)
+                    }
+                    detections_cur_image.append(detection_entry)
+                    if s > max_detection_conf:
+                        max_detection_conf = s
+
+            result['max_detection_conf'] = truncate_float(float(max_detection_conf),
+                                                          precision=CONF_DIGITS)
+            result['detections'] = detections_cur_image
+
+        except Exception as e:
+            result['failure'] = FAILURE_INFER
+            print('TFDetector: image {} failed during inference: {}'.format(image_id, str(e)))
+
+        return result


### PR DESCRIPTION
- `run_tf_detector.py`, which for some time has not been a stand-alone script as we imported functions from `ct_utils`, is renamed as `run_detector.py` and the corresponding class containing inference code for the model file is imported depending on the suffix of the model file path.
- TFDetector is moved to its own module `detection/tf_detector.py`
- PTDetector for the TorchScript YOLOv5 model is in `detection/pt_detector.py`. This will give the same result as using the YOLOv5 repo's `detect.py` with the TorchScript model file, but NOT the same as using the original .pt file and model definitions. The bounding box coordinates seem the same, but the confidence scores are lower. 

Example command:
```
python detection/run_detector.py ".../yolov5_checkpoints/camonly_mosaic_xlarge_dist_5a_last.torchscript.pt" --threshold 0.4 --image_dir test_images/test_images --output_dir test_images_viz
```

Extra dependencies: 
```
- PyTorch
- opencv-python>=4.1.2
- numpy
```