### PR TITLE
Fix for index out of range error for SWG camera trap dataset when using azcopy

### DIFF
--- a/data_management/lila/download_lila_subset.py
+++ b/data_management/lila/download_lila_subset.py
@@ -303,9 +303,7 @@ if use_azcopy_for_download:
         # The container name will be included because it's part of the file name
         container_output_dir = output_dir # os.path.join(output_dir,container_name)
         os.makedirs(container_output_dir,exist_ok=True)
-        
-        filenames = [folder + '/' + s for s in filenames]
-    
+            
         # Write out a list of files, and use the azcopy "list-of-files" option to download those files
         # this azcopy feature is unofficially documented at https://github.com/Azure/azure-storage-azcopy/wiki/Listing-specific-files-to-transfer
         az_filename = os.path.join(output_dir, 'filenames_{}.txt'.format(ds_name.lower().replace(' ','_')))

--- a/data_management/lila/download_lila_subset.py
+++ b/data_management/lila/download_lila_subset.py
@@ -285,9 +285,16 @@ if use_azcopy_for_download:
         assert account_path == 'https://lilablobssc.blob.core.windows.net'
         
         container_and_folder = p.path[1:]
-        
-        container_name = container_and_folder.split('/')[0]
-        folder = container_and_folder.split('/',1)[1]
+           
+        # check if the base url contains a folder, then split it. Otherwise, ignore the nonexistant folder. 
+        if len(container_and_folder.split('/')) == 2:
+            container_name = container_and_folder.split('/')[0]
+            folder = container_and_folder.split('/',1)[1]
+            filenames = [folder + '/' + s for s in filenames]
+        else: 
+            assert(len(container_and_folder.split('/')) == 1)
+            container_name = container_and_folder
+            filenames = ['/' + s for s in filenames]
         
         container_sas_url = account_path + '/' + container_name
         if len(sas_token) > 0:


### PR DESCRIPTION
You can reproduce the original issue with these settings in the downloader:

` ...
datasets_of_interest = ['SWG Camera Traps']

# All lower-case; we'll convert category names to lower-case when comparing
species_of_interest = ['leopard_cat']
`
This will result in an index out of range error as the SWG SAS URL has no folder in the URL, instead they are found in the filenames.

The commits fix this issue by checking the length of the split URL. 