### PR TITLE
Enabled the deletion of frames when processing a folder of videos

### DIFF
--- a/detection/process_video.py
+++ b/detection/process_video.py
@@ -181,7 +181,14 @@ def process_video_folder(options):
             results, frames_json,
             relative_path_base=frame_output_folder)
     
+    ## Delete the frames on which we ran MegaDetector (if not disabled)
+    if not options.keep_output_frames:
+        try:
+            shutil.rmtree(frame_output_folder)
+        except Exception:
+            pass
     
+
     ## Convert frame-level results to video-level results
 
     frame_results_to_video_results(frames_json,video_json)


### PR DESCRIPTION
When processing a single video, the (temporary) directory with the frames is deleted by default. Only if the user specifies `--keep_output_frames` the directory is not deleted. This functionality was not yet implemented for processing a directory with video's (in cases where `input_video_file` points to a directory). With this code addition the frames are deleted by default and are only kept if the user specifies it (just like when processing a single video file). 