### PR TITLE
Removing max_detection_conf field from output format

### DIFF
--- a/api/batch_processing/README.md
+++ b/api/batch_processing/README.md
@@ -205,7 +205,7 @@ Example output with both detection and classification results:
 ```json
 {
     "info": {
-        "format_version": "1.2",
+        "format_version": "1.3",
         "detector": "md_v4.1.0.pb",
         "detection_completion_time": "2019-05-22 02:12:19",
         "classifier": "ecosystem1_v2",
@@ -235,7 +235,6 @@ Example output with both detection and classification results:
         {
             "file": "path/from/base/dir/image_with_animal.jpg",
             "meta": "optional free-text metadata",
-            "max_detection_conf": 0.926,
             "detections": [
                 {
                     "category": "1",
@@ -257,7 +256,6 @@ Example output with both detection and classification results:
         {
             "file": "/path/from/base/dir/empty_image.jpg",
             "meta": "",
-            "max_detection_conf": 0,
             "detections": []
         },
         {

--- a/api/batch_processing/data_preparation/manage_local_batch.ipynb
+++ b/api/batch_processing/data_preparation/manage_local_batch.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5868efcc",
+   "id": "55c86b0b",
    "metadata": {},
    "source": [
     "# Managing a local MegaDetector batch\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee71e1c3",
+   "id": "1e2064e6",
    "metadata": {},
    "source": [
     "## Imports and constants"
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0fe8c0f",
+   "id": "fd7d496f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,6 +40,7 @@
     "# from ai4eutils\n",
     "import ai4e_azure_utils\n",
     "import path_utils\n",
+    "from ct_utils import is_list_sorted\n",
     "\n",
     "from detection.run_detector_batch import load_and_run_detector_batch, write_results_to_file\n",
     "from detection.run_detector import DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD\n",
@@ -75,14 +76,25 @@
     "# OS-specific script comment character\n",
     "scc = '#'\n",
     "\n",
+    "script_extension = '.sh'\n",
+    "\n",
+    "# Prefer threads on Windows, processes on Linux\n",
+    "parallelization_defaults_to_threads = False\n",
+    "\n",
+    "# This is for things like image rendering, not for MegaDetector\n",
+    "default_workers_for_parallel_tasks = 30\n",
+    "\n",
     "if os.name == 'nt':\n",
     "    slcc = '^'\n",
-    "    scc = 'REM'"
+    "    scc = 'REM'\n",
+    "    script_extension = '.bat'\n",
+    "    parallelization_defaults_to_threads = True\n",
+    "    default_workers_for_parallel_tasks = 10"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cbf1e228",
+   "id": "815af58f",
    "metadata": {},
    "source": [
     "## Constants I set per script"
@@ -91,14 +103,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a51d7bdf",
+   "id": "67646b50",
    "metadata": {},
    "outputs": [],
    "source": [
     "input_path = '/datadrive/organization/data'\n",
     "\n",
     "organization_name_short = 'organization'\n",
-    "job_date = None # '2022-12-02'\n",
+    "job_date = None # '2023-04-00'\n",
     "assert job_date is not None and organization_name_short != 'organization'\n",
     "\n",
     "# Optional descriptor\n",
@@ -134,7 +146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b646d3f",
+   "id": "6ffa47b3",
    "metadata": {},
    "source": [
     "## Derived variables, path setup"
@@ -143,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5ba5784",
+   "id": "006a8b8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fcf325a",
+   "id": "1e8dfc0c",
    "metadata": {},
    "source": [
     "## Enumerate files"
@@ -172,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f5356b2",
+   "id": "54a991b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2d509a4",
+   "id": "75e2e67f",
    "metadata": {},
    "source": [
     "## Divide images into chunks"
@@ -210,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81f0c00a",
+   "id": "038530b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32f25029",
+   "id": "10210062",
    "metadata": {},
    "source": [
     "## Estimate total time"
@@ -232,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc939c55",
+   "id": "327a55a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1af71ab0",
+   "id": "b1cb34d9",
    "metadata": {},
    "source": [
     "## Write file lists"
@@ -256,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17de45ca",
+   "id": "499bd31e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "810d0a8f",
+   "id": "b88e6729",
    "metadata": {},
    "source": [
     "## Generate commands"
@@ -280,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6f67d26",
+   "id": "2692b3fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +309,10 @@
     "    else:\n",
     "        gpu_number = default_gpu_number\n",
     "\n",
-    "    cuda_string = f'CUDA_VISIBLE_DEVICES={gpu_number}'\n",
+    "    if os.name == 'nt':\n",
+    "        cuda_string = f'set CUDA_VISIBLE_DEVICES={gpu_number} & '\n",
+    "    else:\n",
+    "        cuda_string = f'CUDA_VISIBLE_DEVICES={gpu_number} '\n",
     "\n",
     "    checkpoint_frequency_string = ''\n",
     "    checkpoint_path_string = ''\n",
@@ -327,8 +342,8 @@
     "\n",
     "    cmd = f'{cuda_string} python run_detector_batch.py \"{model_file}\" \"{chunk_file}\" \"{output_fn}\" {checkpoint_frequency_string} {checkpoint_path_string} {use_image_queue_string} {ncores_string} {quiet_string} {image_size_string}'\n",
     "\n",
-    "    cmd_file = os.path.join(filename_base,'run_chunk_{}_gpu_{}.sh'.format(str(i_task).zfill(2),\n",
-    "                            str(gpu_number).zfill(2)))\n",
+    "    cmd_file = os.path.join(filename_base,'run_chunk_{}_gpu_{}{}'.format(str(i_task).zfill(2),\n",
+    "                            str(gpu_number).zfill(2),script_extension))\n",
     "\n",
     "    with open(cmd_file,'w') as f:\n",
     "        f.write(cmd + '\\n')\n",
@@ -343,8 +358,8 @@
     "\n",
     "    resume_string = ' --resume_from_checkpoint \"{}\"'.format(checkpoint_filename)\n",
     "    resume_cmd = cmd + resume_string\n",
-    "    resume_cmd_file = os.path.join(filename_base,'resume_chunk_{}_gpu_{}.sh'.format(str(i_task).zfill(2),\n",
-    "                            str(gpu_number).zfill(2)))\n",
+    "    resume_cmd_file = os.path.join(filename_base,'resume_chunk_{}_gpu_{}{}'.format(str(i_task).zfill(2),\n",
+    "                            str(gpu_number).zfill(2),script_extension))\n",
     "\n",
     "    with open(resume_cmd_file,'w') as f:\n",
     "        f.write(resume_cmd + '\\n')\n",
@@ -358,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cabac3d",
+   "id": "cc38125f",
    "metadata": {},
    "source": [
     "## Run the tasks"
@@ -367,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2327714",
+   "id": "92964d5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b00bc9d",
+   "id": "6824f209",
    "metadata": {},
    "source": [
     "## Load results, look for failed or missing images in each task"
@@ -441,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b52c767b",
+   "id": "525ae2ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e06a0207",
+   "id": "7265870b",
    "metadata": {},
    "source": [
     "## Merge results files and make images relative"
@@ -501,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe529615",
+   "id": "1f2c7060",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f140eb0",
+   "id": "b2bbdc12",
    "metadata": {},
    "source": [
     "## Post-processing (no ground truth)"
@@ -553,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a480c8c5",
+   "id": "4e5aeab0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,8 +585,8 @@
     "# options.sample_seed = 0\n",
     "\n",
     "options.parallelize_rendering = True\n",
-    "options.parallelize_rendering_n_cores = 50\n",
-    "options.parallelize_rendering_with_threads = False\n",
+    "options.parallelize_rendering_n_cores = default_workers_for_parallel_tasks\n",
+    "options.parallelize_rendering_with_threads = parallelization_defaults_to_threads\n",
     "\n",
     "if render_animals_only:\n",
     "    # Omit some pages from the output, useful when animals are rare\n",
@@ -595,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcb7ca95",
+   "id": "3763f231",
    "metadata": {},
    "source": [
     "## RDE (sample directory collapsing)"
@@ -604,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "743e3cb5",
+   "id": "88f59550",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,7 +666,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7c67726",
+   "id": "022052da",
    "metadata": {},
    "source": [
     "## Repeat detection elimination, phase 1"
@@ -660,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a12b122c",
+   "id": "31d3abb7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,8 +694,8 @@
     "options.maxSuspiciousDetectionSize = 0.2\n",
     "# options.minSuspiciousDetectionSize = 0.05\n",
     "\n",
-    "# options.parallelizationUsesThreads = True\n",
-    "# options.nWorkers = 10\n",
+    "options.parallelizationUsesThreads = parallelization_defaults_to_threads\n",
+    "options.nWorkers = default_workers_for_parallel_tasks\n",
     "\n",
     "# This will cause a very light gray box to get drawn around all the detections\n",
     "# we're *not* considering as suspicious.\n",
@@ -726,7 +741,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ab8c0a1",
+   "id": "50bf0d6b",
    "metadata": {},
    "source": [
     "## Manual RDE step"
@@ -735,7 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68c60dda",
+   "id": "7057a90a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +759,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "014a7524",
+   "id": "4efe3fce",
    "metadata": {},
    "source": [
     "## Re-filtering"
@@ -753,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "415cd7ea",
+   "id": "193352a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +785,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06945201",
+   "id": "3bf10a47",
    "metadata": {},
    "source": [
     "## Post-processing (post-RDE)"
@@ -779,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b570d32",
+   "id": "d0543493",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,8 +811,8 @@
     "# options.sample_seed = 0\n",
     "\n",
     "options.parallelize_rendering = True\n",
-    "options.parallelize_rendering_n_cores = 50\n",
-    "options.parallelize_rendering_with_threads = False\n",
+    "options.parallelize_rendering_n_cores = default_workers_for_parallel_tasks\n",
+    "options.parallelize_rendering_with_threads = parallelization_defaults_to_threads\n",
     "\n",
     "if render_animals_only:\n",
     "    # Omit some pages from the output, useful when animals are rare\n",
@@ -823,7 +838,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c756ef9",
+   "id": "80818026",
    "metadata": {},
    "source": [
     "## Run MegaClassifier (actually, write out a script that runs MegaClassifier)"
@@ -832,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9011ab6",
+   "id": "39f367a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -849,7 +864,7 @@
     "output_base = combined_api_output_folder\n",
     "device_id = 0\n",
     "\n",
-    "output_file = os.path.join(filename_base,'run_{}_'.format(classifier_name_short) + job_name +  '.sh')\n",
+    "output_file = os.path.join(filename_base,'run_{}_'.format(classifier_name_short) + job_name + script_extension)\n",
     "\n",
     "classifier_base = os.path.expanduser('~/models/camera_traps/megaclassifier/v0.1/')\n",
     "assert os.path.isdir(classifier_base)\n",
@@ -866,10 +881,10 @@
     "classifier_output_suffix = '_megaclassifier_output.csv.gz'\n",
     "final_output_suffix = '_megaclassifier.json'\n",
     "\n",
-    "n_threads_str = '50'\n",
+    "n_threads_str = str(default_workers_for_parallel_tasks)\n",
     "image_size_str = '300'\n",
     "batch_size_str = '64'\n",
-    "num_workers_str = '8'\n",
+    "num_workers_str = str(default_workers_for_parallel_tasks)\n",
     "classification_threshold_str = '0.05'\n",
     "\n",
     "logdir = filename_base\n",
@@ -898,8 +913,8 @@
     "    crop_cmd += crop_comment\n",
     "\n",
     "    crop_cmd += \"python crop_detections.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + input_file_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + crop_path + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + input_file_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + crop_path + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--images-dir \"' + image_base + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--threshold \"' + threshold_str + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--square-crops ' + ' ' + slcc + '\\n' + \\\n",
@@ -926,9 +941,9 @@
     "    classify_cmd += classify_comment\n",
     "\n",
     "    classify_cmd += \"python run_classifier.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + checkpoint_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + crop_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + classifier_output_path + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + checkpoint_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + crop_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + classifier_output_path + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--detections-json \"' + input_file_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--classifier-categories \"' + classifier_categories_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--image-size \"' + image_size_str + '\"' + ' ' + slcc + '\\n' + \\\n",
@@ -965,7 +980,7 @@
     "    remap_cmd += remap_comment\n",
     "\n",
     "    remap_cmd += \"python aggregate_classifier_probs.py \" + slcc + \"\\n\" + \\\n",
-    "        ' ' + classifier_output_path + ' ' + slcc + '\\n' + \\\n",
+    "        ' \"' + classifier_output_path + '\" ' + slcc + '\\n' + \\\n",
     "        ' ' + '--target-mapping \"' + target_mapping_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "        ' ' + '--output-csv \"' + classifier_output_path_remapped + '\"' + ' ' + slcc + '\\n' + \\\n",
     "        ' ' + '--output-label-index \"' + output_label_index + '\"' \\\n",
@@ -1005,8 +1020,8 @@
     "    merge_cmd += merge_comment\n",
     "\n",
     "    merge_cmd += \"python merge_classification_detection_output.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + classifier_output_path_remapped + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + output_label_index + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + classifier_output_path_remapped + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + output_label_index + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--output-json \"' + final_output_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--detection-json \"' + input_file_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--classifier-name \"' + classifier_name + '\"' + ' ' + slcc + '\\n' + \\\n",
@@ -1030,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df4b8091",
+   "id": "85b55368",
    "metadata": {},
    "source": [
     "## Run a non-MegaClassifier classifier (i.e., a classifier with no output mapping)"
@@ -1039,7 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e093eeb",
+   "id": "10bcee8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1071,7 @@
     "output_base = combined_api_output_folder\n",
     "device_id = 1\n",
     "\n",
-    "output_file = os.path.join(filename_base,'run_{}_'.format(classifier_name_short) + job_name +  '.sh')\n",
+    "output_file = os.path.join(filename_base,'run_{}_'.format(classifier_name_short) + job_name +  script_extension)\n",
     "\n",
     "classifier_base = os.path.expanduser('~/models/camera_traps/idfg_classifier/idfg_classifier_20200905_042558')\n",
     "assert os.path.isdir(classifier_base)\n",
@@ -1071,10 +1086,10 @@
     "final_output_suffix = '_{}.json'.format(classifier_name_short)\n",
     "\n",
     "threshold_str = '0.65'\n",
-    "n_threads_str = '50'\n",
+    "n_threads_str = str(default_workers_for_parallel_tasks)\n",
     "image_size_str = '300'\n",
     "batch_size_str = '64'\n",
-    "num_workers_str = '8'\n",
+    "num_workers_str = str(default_workers_for_parallel_tasks)\n",
     "logdir = filename_base\n",
     "\n",
     "classification_threshold_str = '0.05'\n",
@@ -1103,8 +1118,8 @@
     "    crop_cmd += crop_comment\n",
     "\n",
     "    crop_cmd += \"python crop_detections.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + input_file_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + crop_path + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + input_file_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + crop_path + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--images-dir \"' + image_base + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--threshold \"' + threshold_str + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--square-crops ' + ' ' + slcc + '\\n' + \\\n",
@@ -1131,9 +1146,9 @@
     "    classify_cmd += classify_comment\n",
     "\n",
     "    classify_cmd += \"python run_classifier.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + checkpoint_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + crop_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + classifier_output_path + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + checkpoint_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + crop_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + classifier_output_path + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--detections-json \"' + input_file_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--classifier-categories \"' + classifier_categories_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--image-size \"' + image_size_str + '\"' + ' ' + slcc + '\\n' + \\\n",
@@ -1171,8 +1186,8 @@
     "    merge_cmd += merge_comment\n",
     "\n",
     "    merge_cmd += \"python merge_classification_detection_output.py \" + slcc + \"\\n\" + \\\n",
-    "    \t ' ' + classifier_output_path + ' ' + slcc + '\\n' + \\\n",
-    "         ' ' + classifier_categories_path + ' ' + slcc + '\\n' + \\\n",
+    "    \t ' \"' + classifier_output_path + '\" ' + slcc + '\\n' + \\\n",
+    "         ' \"' + classifier_categories_path + '\" ' + slcc + '\\n' + \\\n",
     "         ' ' + '--output-json \"' + final_output_path_ic + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--detection-json \"' + input_file_path + '\"' + ' ' + slcc + '\\n' + \\\n",
     "         ' ' + '--classifier-name \"' + classifier_name + '\"' + ' ' + slcc + '\\n' + \\\n",
@@ -1196,7 +1211,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a2a6485",
+   "id": "2895494c",
+   "metadata": {},
+   "source": [
+    "## Run the classifier(s) via the .sh script(s) write just wrote"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adf5f9ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42b7cc3c",
    "metadata": {},
    "source": [
     "## Within-image classification smoothing"
@@ -1205,10 +1238,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bedfd36",
+   "id": "88bf4ad6",
    "metadata": {},
    "outputs": [],
    "source": [
+    "#\n",
     "# Only count detections with a classification confidence threshold above\n",
     "# *classification_confidence_threshold*, which in practice means we're only\n",
     "# looking at one category per detection.\n",
@@ -1220,25 +1254,39 @@
     "#\n",
     "# Optionally treat some classes as particularly unreliable, typically used to overwrite an\n",
     "# \"other\" class.\n",
+    "#\n",
+    "# This cell also removes everything but the non-dominant classification for each detection.\n",
+    "#\n",
+    "\n",
+    "# How many detections do we need above the classification threshold to determine a dominant category\n",
+    "# for an image?\n",
+    "min_detections_above_threshold = 4\n",
+    "\n",
+    "# Even if we have a dominant class, if a non-dominant class has at least this many classifications\n",
+    "# in an image, leave them alone.\n",
+    "max_detections_secondary_class = 3\n",
+    "\n",
+    "# If the dominant class has at least this many classifications, overwrite \"other\" classifications\n",
+    "min_detections_to_overwrite_other = 2\n",
+    "other_category_names = ['other']\n",
+    "\n",
+    "# What confidence threshold should we use for assessing the dominant category in an image?\n",
+    "classification_confidence_threshold = 0.6\n",
+    "\n",
+    "# Which classifications should we even bother over-writing?\n",
+    "classification_overwrite_threshold = 0.3\n",
+    "\n",
+    "# Detection confidence threshold for things we count when determining a dominant class\n",
+    "detection_confidence_threshold = 0.2\n",
+    "\n",
+    "# Which detections should we even bother over-writing?\n",
+    "detection_overwrite_threshold = 0.05\n",
     "\n",
     "classification_detection_files = [\n",
-    "    final_output_path_mc,\n",
-    "    final_output_path_ic\n",
+    "    final_output_path_mc,final_output_path_ic\n",
     "    ]\n",
     "\n",
     "assert all([os.path.isfile(fn) for fn in classification_detection_files])\n",
-    "\n",
-    "# Only count detections with a classification confidence threshold above\n",
-    "# *classification_confidence_threshold*, which in practice means we're only\n",
-    "# looking at one category per detection.\n",
-    "#\n",
-    "# If an image has at least *min_detections_above_threshold* such detections\n",
-    "# in the most common category, and no more than *max_detections_secondary_class*\n",
-    "# in the second-most-common category, flip all detections to the most common\n",
-    "# category.\n",
-    "#\n",
-    "# Optionally treat some classes as particularly unreliable, typically used to overwrite an\n",
-    "# \"other\" class.\n",
     "\n",
     "smoothed_classification_files = []\n",
     "\n",
@@ -1251,30 +1299,7 @@
     "    with open(classifier_output_path,'r') as f:\n",
     "        d = json.load(f)\n",
     "\n",
-    "    # d['classification_categories']\n",
-    "\n",
-    "    # im['detections']\n",
-    "\n",
-    "    # path_utils.open_file(os.path.join(input_path,im['file']))\n",
-    "\n",
     "    from collections import defaultdict\n",
-    "\n",
-    "    min_detections_above_threshold = 4\n",
-    "    max_detections_secondary_class = 3\n",
-    "\n",
-    "    min_detections_to_overwrite_other = 2\n",
-    "    other_category_names = ['other']\n",
-    "\n",
-    "    classification_confidence_threshold = 0.6\n",
-    "\n",
-    "    # Which classifications should we even bother over-writing?\n",
-    "    classification_overwrite_threshold = 0.3 # classification_confidence_threshold\n",
-    "\n",
-    "    # Detection confidence threshold for things we count\n",
-    "    detection_confidence_threshold = 0.2\n",
-    "\n",
-    "    # Which detections should we even bother over-writing?\n",
-    "    detection_overwrite_threshold = 0.05\n",
     "\n",
     "    category_name_to_id = {d['classification_categories'][k]:k for k in d['classification_categories']}\n",
     "    other_category_ids = []\n",
@@ -1290,6 +1315,28 @@
     "\n",
     "    n_detections_flipped = 0\n",
     "    n_images_changed = 0\n",
+    "\n",
+    "    # Before we do anything else, get rid of everything but the top classification\n",
+    "    # for each detection.\n",
+    "    for im in tqdm(d['images']):\n",
+    "\n",
+    "        if 'detections' not in im or im['detections'] is None or len(im['detections']) == 0:\n",
+    "            continue\n",
+    "\n",
+    "        detections = im['detections']\n",
+    "\n",
+    "        for det in detections:\n",
+    "\n",
+    "            if 'classifications' not in det or len(det['classifications']) == 0:\n",
+    "                continue\n",
+    "\n",
+    "            classification_confidence_values = [c[1] for c in det['classifications']]\n",
+    "            assert is_list_sorted(classification_confidence_values,reverse=True)\n",
+    "            det['classifications'] = [det['classifications'][0]]\n",
+    "\n",
+    "        # ...for each detection in this image\n",
+    "\n",
+    "    # ...for each image\n",
     "\n",
     "    # im = d['images'][0]\n",
     "    for im in tqdm(d['images']):\n",
@@ -1423,16 +1470,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2af88d77",
+   "id": "51ac6a88",
    "metadata": {},
    "source": [
-    "## Post-processing (post-classification)"
+    "## Post-processing (post-classification, post-within-image-smoothing)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b14998b9",
+   "id": "53094c19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1454,8 +1501,8 @@
     "    options.separate_detections_by_category = True\n",
     "\n",
     "    options.parallelize_rendering = True\n",
-    "    options.parallelize_rendering_n_cores = 50\n",
-    "    options.parallelize_rendering_with_threads = False\n",
+    "    options.parallelize_rendering_n_cores = default_workers_for_parallel_tasks\n",
+    "    options.parallelize_rendering_with_threads = parallelization_defaults_to_threads\n",
     "\n",
     "    folder_token = classification_detection_file.split(os.path.sep)[-1].replace('classifier.json','')\n",
     "\n",
@@ -1472,7 +1519,575 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b68b86c8",
+   "id": "56eba400",
+   "metadata": {},
+   "source": [
+    "## Read EXIF data from all images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "511bd62c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_management import read_exif\n",
+    "exif_options = read_exif.ReadExifOptions()\n",
+    "\n",
+    "exif_options.verbose = False\n",
+    "exif_options.n_workers = default_workers_for_parallel_tasks\n",
+    "exif_options.use_threads = parallelization_defaults_to_threads\n",
+    "exif_options.processing_library = 'pil'\n",
+    "\n",
+    "exif_results_file = os.path.join(filename_base,'exif_data.json')\n",
+    "\n",
+    "if os.path.isfile(exif_results_file):\n",
+    "    print('Reading EXIF results from {}'.format(exif_results_file))\n",
+    "    with open(exif_results_file,'r') as f:\n",
+    "        exif_results = json.load(f)\n",
+    "else:\n",
+    "    exif_results = read_exif.read_exif_from_folder(input_path,\n",
+    "                                                   output_file=exif_results_file,\n",
+    "                                                   options=exif_options)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "654b5dfa",
+   "metadata": {},
+   "source": [
+    "## Prepare COCO-camera-traps-compatible image objects for EXIF results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9c48bd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import dateutil\n",
+    "import datetime\n",
+    "import time\n",
+    "\n",
+    "def parse_date_from_exif_datetime(s):\n",
+    "\n",
+    "    # This is a standard format for EXIF datetime, and dateutil.parser\n",
+    "    # doesn't handle it correctly.\n",
+    "\n",
+    "    # return dateutil.parser.parse(s)\n",
+    "    return time.strptime(s, '%Y:%m:%d %H:%M:%S')\n",
+    "\n",
+    "now = datetime.datetime.now()\n",
+    "\n",
+    "image_info = []\n",
+    "\n",
+    "# exif_result = exif_results[0]\n",
+    "for exif_result in tqdm(exif_results):\n",
+    "\n",
+    "    im = {}\n",
+    "\n",
+    "    # Currently we assume that each leaf-node folder is a location\n",
+    "    im['location'] = os.path.dirname(exif_result['file_name'])\n",
+    "    im['file_name'] = exif_result['file_name']\n",
+    "    im['id'] = im['file_name']\n",
+    "    exif_dt = exif_result['exif_tags']['DateTime']\n",
+    "    im['datetime'] = datetime.datetime.fromtimestamp(\n",
+    "        time.mktime(parse_date_from_exif_datetime(exif_dt)))\n",
+    "\n",
+    "    # We collected this image this century, but not today, make sure the parsed datetime\n",
+    "    # jives with that.\n",
+    "    #\n",
+    "    # The latter check is to make sure we don't repeat a particular pathological approach\n",
+    "    # to datetime parsing, where dateutil parses time correctly, but swaps in the current\n",
+    "    # date when it's not sure where the date is.\n",
+    "    assert im['datetime'].year >= 2000\n",
+    "    assert (now - im['datetime']).total_seconds() > 1*24*60*60\n",
+    "\n",
+    "    image_info.append(im)\n",
+    "\n",
+    "# ...for each exif image result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45f86553",
+   "metadata": {},
+   "source": [
+    "## Assemble into sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7850246",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import defaultdict\n",
+    "from data_management import cct_json_utils\n",
+    "\n",
+    "print('Assembling images into sequences')\n",
+    "\n",
+    "cct_json_utils.create_sequences(image_info)\n",
+    "\n",
+    "# Make a list of images appearing at each location\n",
+    "sequence_to_images = defaultdict(list)\n",
+    "\n",
+    "# im = image_info[0]\n",
+    "for im in tqdm(image_info):\n",
+    "    sequence_to_images[im['seq_id']].append(im)\n",
+    "\n",
+    "all_sequences = list(sorted(sequence_to_images.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed4d983e",
+   "metadata": {},
+   "source": [
+    "## Load classification results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3667544",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sequence_level_smoothing_input_file = smoothed_classification_files[0]\n",
+    "\n",
+    "with open(sequence_level_smoothing_input_file,'r') as f:\n",
+    "    d = json.load(f)\n",
+    "\n",
+    "# Map each filename to classification results for that file\n",
+    "filename_to_results = {}\n",
+    "\n",
+    "for im in tqdm(d['images']):\n",
+    "    filename_to_results[im['file'].replace('\\\\','/')] = im"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a358edc",
+   "metadata": {},
+   "source": [
+    "## Smooth classification results over sequences (prep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3408934b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ct_utils import is_list_sorted\n",
+    "\n",
+    "classification_category_id_to_name = d['classification_categories']\n",
+    "classification_category_name_to_id = {v: k for k, v in classification_category_id_to_name.items()}\n",
+    "\n",
+    "class_names = list(classification_category_id_to_name.values())\n",
+    "\n",
+    "animal_detection_category = '1'\n",
+    "assert(d['detection_categories'][animal_detection_category] == 'animal')\n",
+    "\n",
+    "other_category_names = set(['other'])\n",
+    "other_category_ids = set([classification_category_name_to_id[s] for s in other_category_names])\n",
+    "\n",
+    "# These are the only classes to which we're going to switch other classifications\n",
+    "category_names_to_smooth_to = set(['deer','elk','cow','canid','cat','bird','bear'])\n",
+    "category_ids_to_smooth_to = set([classification_category_name_to_id[s] for s in category_names_to_smooth_to])\n",
+    "assert all([s in class_names for s in category_names_to_smooth_to])\n",
+    "\n",
+    "# Only switch classifications to the dominant class if we see the dominant class at least\n",
+    "# this many times\n",
+    "min_dominant_class_classifications_above_threshold_for_class_smoothing = 5 # 2\n",
+    "\n",
+    "# If we see more than this many of a class that are above threshold, don't switch those\n",
+    "# classifications to the dominant class.\n",
+    "max_secondary_class_classifications_above_threshold_for_class_smoothing = 5\n",
+    "\n",
+    "# If the ratio between a dominant class and a secondary class count is greater than this,\n",
+    "# regardless of the secondary class count, switch those classificaitons (i.e., ignore\n",
+    "# max_secondary_class_classifications_above_threshold_for_class_smoothing).\n",
+    "#\n",
+    "# This may be different for different dominant classes, e.g. if we see lots of cows, they really\n",
+    "# tend to be cows.  Less so for canids, so we set a higher \"override ratio\" for canids.\n",
+    "min_dominant_class_ratio_for_secondary_override_table = {classification_category_name_to_id['cow']:2,None:3}\n",
+    "\n",
+    "# If there are at least this many classifications for the dominant class in a sequence,\n",
+    "# regardless of what that class is, convert all 'other' classifications (regardless of\n",
+    "# confidence) to that class.\n",
+    "min_dominant_class_classifications_above_threshold_for_other_smoothing = 3 # 2\n",
+    "\n",
+    "# If there are at least this many classifications for the dominant class in a sequence,\n",
+    "# regardless of what that class is, classify all previously-unclassified detections\n",
+    "# as that class.\n",
+    "min_dominant_class_classifications_above_threshold_for_unclassified_smoothing = 3 # 2\n",
+    "\n",
+    "# Only count classifications above this confidence level when determining the dominant\n",
+    "# class, and when deciding whether to switch other classifications.\n",
+    "classification_confidence_threshold = 0.6\n",
+    "\n",
+    "# Confidence values to use when we change a detection's classification (the\n",
+    "# original confidence value is irrelevant at that point)\n",
+    "flipped_other_confidence_value = 0.6\n",
+    "flipped_class_confidence_value = 0.6\n",
+    "flipped_unclassified_confidence_value = 0.6\n",
+    "\n",
+    "min_detection_confidence_for_unclassified_flipping = 0.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39a30fad",
+   "metadata": {},
+   "source": [
+    "## Smooth classification results over sequences (supporting functions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "641b860c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def results_for_sequence(images_this_sequence):\n",
+    "    \"\"\"\n",
+    "    Fetch MD results for every image in this sequence, based on the 'file_name' field\n",
+    "    \"\"\"\n",
+    "\n",
+    "    results_this_sequence = []\n",
+    "    for im in images_this_sequence:\n",
+    "        fn = im['file_name']\n",
+    "        results_this_image = filename_to_results[fn]\n",
+    "        assert isinstance(results_this_image,dict)\n",
+    "        results_this_sequence.append(results_this_image)\n",
+    "\n",
+    "    return results_this_sequence\n",
+    "\n",
+    "\n",
+    "def top_classifications_for_sequence(images_this_sequence):\n",
+    "    \"\"\"\n",
+    "    Return all top-1 animal classifications for every detection in this\n",
+    "    sequence, regardless of  confidence\n",
+    "\n",
+    "    May modify [images_this_sequence] (removing non-top-1 classifications)\n",
+    "    \"\"\"\n",
+    "\n",
+    "    classifications_this_sequence = []\n",
+    "\n",
+    "    # im = images_this_sequence[0]\n",
+    "    for im in images_this_sequence:\n",
+    "\n",
+    "        fn = im['file_name']\n",
+    "        results_this_image = filename_to_results[fn]\n",
+    "\n",
+    "        if results_this_image['detections'] is None:\n",
+    "            continue\n",
+    "\n",
+    "        # det = results_this_image['detections'][0]\n",
+    "        for det in results_this_image['detections']:\n",
+    "\n",
+    "            # Only process animal detections\n",
+    "            if det['category'] != animal_detection_category:\n",
+    "                continue\n",
+    "\n",
+    "            # Only process detections with classification information\n",
+    "            if 'classifications' not in det:\n",
+    "                continue\n",
+    "\n",
+    "            # We only care about top-1 classifications, remove everything else\n",
+    "            if len(det['classifications']) > 1:\n",
+    "\n",
+    "                # Make sure the list of classifications is already sorted by confidence\n",
+    "                classification_confidence_values = [c[1] for c in det['classifications']]\n",
+    "                assert is_list_sorted(classification_confidence_values,reverse=True)\n",
+    "\n",
+    "                # ...and just keep the first one\n",
+    "                det['classifications'] = [det['classifications'][0]]\n",
+    "\n",
+    "            # Confidence values should be sorted within a detection; verify this, and ignore\n",
+    "            top_classification = det['classifications'][0]\n",
+    "\n",
+    "            classifications_this_sequence.append(top_classification)\n",
+    "\n",
+    "        # ...for each detection in this image\n",
+    "\n",
+    "    # ...for each image in this sequence\n",
+    "\n",
+    "    return classifications_this_sequence\n",
+    "\n",
+    "# ...top_classifications_for_sequence()\n",
+    "\n",
+    "\n",
+    "def count_above_threshold_classifications(classifications_this_sequence):\n",
+    "    \"\"\"\n",
+    "    Given a list of classification objects (tuples), return a dict mapping\n",
+    "    category IDs to the count of above-threshold classifications.\n",
+    "\n",
+    "    This dict's keys will be sorted in descending order by frequency.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Count above-threshold classifications in this sequence\n",
+    "    category_to_count = defaultdict(int)\n",
+    "    for c in classifications_this_sequence:\n",
+    "        if c[1] >= classification_confidence_threshold:\n",
+    "            category_to_count[c[0]] += 1\n",
+    "\n",
+    "    # Sort the dictionary in descending order by count\n",
+    "    category_to_count = {k: v for k, v in sorted(category_to_count.items(),\n",
+    "                                                 key=lambda item: item[1],\n",
+    "                                                 reverse=True)}\n",
+    "\n",
+    "    keys_sorted_by_frequency = list(category_to_count.keys())\n",
+    "\n",
+    "    # Handle a quirky special case: if the most common category is \"other\" and\n",
+    "    # it's \"tied\" with the second-most-common category, swap them.\n",
+    "    if len(other_category_names) > 0:\n",
+    "        if (len(keys_sorted_by_frequency) > 1) and \\\n",
+    "            (keys_sorted_by_frequency[0] in other_category_names) and \\\n",
+    "            (keys_sorted_by_frequency[1] not in other_category_names) and \\\n",
+    "            (category_to_count[keys_sorted_by_frequency[0]] == \\\n",
+    "             category_to_count[keys_sorted_by_frequency[1]]):\n",
+    "                keys_sorted_by_frequency[1], keys_sorted_by_frequency[0] = \\\n",
+    "                    keys_sorted_by_frequency[0], keys_sorted_by_frequency[1]\n",
+    "\n",
+    "    sorted_category_to_count = {}\n",
+    "    for k in keys_sorted_by_frequency:\n",
+    "        sorted_category_to_count[k] = category_to_count[k]\n",
+    "\n",
+    "    return sorted_category_to_count\n",
+    "\n",
+    "# ...def count_above_threshold_classifications()\n",
+    "\n",
+    "def sort_images_by_time(images):\n",
+    "    \"\"\"\n",
+    "    Returns a copy of [images], sorted by the 'datetime' field (ascending).\n",
+    "    \"\"\"\n",
+    "    return sorted(images, key = lambda im: im['datetime'])\n",
+    "\n",
+    "\n",
+    "def get_first_key_from_sorted_dictionary(di):\n",
+    "    if len(di) == 0:\n",
+    "        return None\n",
+    "    return next(iter(di.items()))[0]\n",
+    "\n",
+    "\n",
+    "def get_first_value_from_sorted_dictionary(di):\n",
+    "    if len(di) == 0:\n",
+    "        return None\n",
+    "    return next(iter(di.items()))[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "137de6c1",
+   "metadata": {},
+   "source": [
+    "## Smooth classifications at the sequence level (main loop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55bcceb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_other_flips = 0\n",
+    "n_classification_flips = 0\n",
+    "n_unclassified_flips = 0\n",
+    "\n",
+    "# Break if this token is contained in a filename (set to None for normal operation)\n",
+    "debug_fn = None\n",
+    "\n",
+    "# i_sequence = 0; seq_id = all_sequences[i_sequence]\n",
+    "for i_sequence,seq_id in tqdm(enumerate(all_sequences),total=len(all_sequences)):\n",
+    "\n",
+    "    images_this_sequence = sequence_to_images[seq_id]\n",
+    "\n",
+    "    # Count top-1 classifications in this sequence (regardless of confidence)\n",
+    "    classifications_this_sequence = top_classifications_for_sequence(images_this_sequence)\n",
+    "\n",
+    "    # Handy debugging code for looking at the numbers for a particular sequence\n",
+    "    for im in images_this_sequence:\n",
+    "        if debug_fn is not None and debug_fn in im['file_name']:\n",
+    "            raise ValueError('')\n",
+    "\n",
+    "    if len(classifications_this_sequence) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    # Count above-threshold classifications for each category\n",
+    "    sorted_category_to_count = count_above_threshold_classifications(classifications_this_sequence)\n",
+    "\n",
+    "    if len(sorted_category_to_count) == 0:\n",
+    "        continue\n",
+    "\n",
+    "    max_count = get_first_value_from_sorted_dictionary(sorted_category_to_count)\n",
+    "    dominant_category_id = get_first_key_from_sorted_dictionary(sorted_category_to_count)\n",
+    "\n",
+    "    # If our dominant category ID isn't something we want to smooth to, don't mess around with this sequence\n",
+    "    if dominant_category_id not in category_ids_to_smooth_to:\n",
+    "        continue\n",
+    "\n",
+    "\n",
+    "    ## Smooth \"other\" classifications ##\n",
+    "\n",
+    "    if max_count >= min_dominant_class_classifications_above_threshold_for_other_smoothing:\n",
+    "        for c in classifications_this_sequence:\n",
+    "            if c[0] in other_category_ids:\n",
+    "                n_other_flips += 1\n",
+    "                c[0] = dominant_category_id\n",
+    "                c[1] = flipped_other_confidence_value\n",
+    "\n",
+    "\n",
+    "    # By not re-computing \"max_count\" here, we are making a decision that the count used\n",
+    "    # to decide whether a class should overwrite another class does not include any \"other\"\n",
+    "    # classifications we changed to be the dominant class.  If we wanted to include those...\n",
+    "    #\n",
+    "    # sorted_category_to_count = count_above_threshold_classifications(classifications_this_sequence)\n",
+    "    # max_count = get_first_value_from_sorted_dictionary(sorted_category_to_count)\n",
+    "    # assert dominant_category_id == get_first_key_from_sorted_dictionary(sorted_category_to_count)\n",
+    "\n",
+    "\n",
+    "    ## Smooth non-dominant classes ##\n",
+    "\n",
+    "    if max_count >= min_dominant_class_classifications_above_threshold_for_class_smoothing:\n",
+    "\n",
+    "        # Don't flip classes to the dominant class if they have a large number of classifications\n",
+    "        category_ids_not_to_flip = set()\n",
+    "\n",
+    "        for category_id in sorted_category_to_count.keys():\n",
+    "            secondary_class_count = sorted_category_to_count[category_id]\n",
+    "            dominant_to_secondary_ratio = max_count / secondary_class_count\n",
+    "\n",
+    "            # Don't smooth over this class if there are a bunch of them, and the ratio\n",
+    "            # if primary to secondary class count isn't too large\n",
+    "\n",
+    "            # Default ratio\n",
+    "            ratio_for_override = min_dominant_class_ratio_for_secondary_override_table[None]\n",
+    "\n",
+    "            # Does this dominant class have a custom ratio?\n",
+    "            if dominant_category_id in min_dominant_class_ratio_for_secondary_override_table:\n",
+    "                ratio_for_override = \\\n",
+    "                    min_dominant_class_ratio_for_secondary_override_table[dominant_category_id]\n",
+    "\n",
+    "            if (dominant_to_secondary_ratio < ratio_for_override) and \\\n",
+    "                (secondary_class_count > \\\n",
+    "                 max_secondary_class_classifications_above_threshold_for_class_smoothing):\n",
+    "                category_ids_not_to_flip.add(category_id)\n",
+    "\n",
+    "        for c in classifications_this_sequence:\n",
+    "            if c[0] not in category_ids_not_to_flip and c[0] != dominant_category_id:\n",
+    "                c[0] = dominant_category_id\n",
+    "                c[1] = flipped_class_confidence_value\n",
+    "                n_classification_flips += 1\n",
+    "\n",
+    "\n",
+    "    ## Smooth unclassified detections ##\n",
+    "\n",
+    "    if max_count >= min_dominant_class_classifications_above_threshold_for_unclassified_smoothing:\n",
+    "\n",
+    "        results_this_sequence = results_for_sequence(images_this_sequence)\n",
+    "        detections_this_sequence = []\n",
+    "        for r in results_this_sequence:\n",
+    "            if r['detections'] is not None:\n",
+    "                detections_this_sequence.extend(r['detections'])\n",
+    "        for det in detections_this_sequence:\n",
+    "            if 'classifications' in det and len(det['classifications']) > 0:\n",
+    "                continue\n",
+    "            if det['category'] != animal_detection_category:\n",
+    "                continue\n",
+    "            if det['conf'] < min_detection_confidence_for_unclassified_flipping:\n",
+    "                continue\n",
+    "            det['classifications'] = [[dominant_category_id,flipped_unclassified_confidence_value]]\n",
+    "            n_unclassified_flips += 1\n",
+    "\n",
+    "# ...for each sequence\n",
+    "\n",
+    "print('\\Finished sequence smoothing\\n')\n",
+    "print('Flipped {} \"other\" classifications'.format(n_other_flips))\n",
+    "print('Flipped {} species classifications'.format(n_classification_flips))\n",
+    "print('Flipped {} unclassified detections'.format(n_unclassified_flips))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c826c54",
+   "metadata": {},
+   "source": [
+    "## Write smoothed classification results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a43627f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sequence_smoothed_classification_file = sequence_level_smoothing_input_file.replace(\n",
+    "    '.json','_seqsmoothing.json')\n",
+    "\n",
+    "print('Writing sequence-smoothed classification results to {}'.format(\n",
+    "    sequence_smoothed_classification_file))\n",
+    "\n",
+    "with open(sequence_smoothed_classification_file,'w') as f:\n",
+    "    json.dump(d,f,indent=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "053a6fab",
+   "metadata": {},
+   "source": [
+    "## Post-processing (post-classification, post-within-image-and-within-sequence-smoothing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c074ad56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "options = PostProcessingOptions()\n",
+    "options.image_base_dir = input_path\n",
+    "options.include_almost_detections = True\n",
+    "options.num_images_to_sample = 10000\n",
+    "options.confidence_threshold = 0.2\n",
+    "options.classification_confidence_threshold = 0.7\n",
+    "options.almost_detection_confidence_threshold = options.confidence_threshold - 0.05\n",
+    "options.ground_truth_json_file = None\n",
+    "options.separate_detections_by_category = True\n",
+    "\n",
+    "options.parallelize_rendering = True\n",
+    "options.parallelize_rendering_n_cores = default_workers_for_parallel_tasks\n",
+    "options.parallelize_rendering_with_threads = parallelization_defaults_to_threads\n",
+    "\n",
+    "folder_token = sequence_smoothed_classification_file.split(os.path.sep)[-1].replace(\n",
+    "    '_within_image_smoothing_seqsmoothing','')\n",
+    "folder_token = folder_token.replace('.json','_seqsmoothing')\n",
+    "\n",
+    "output_base = os.path.join(postprocessing_output_folder, folder_token + \\\n",
+    "    base_task_name + '_{:.3f}'.format(options.confidence_threshold))\n",
+    "os.makedirs(output_base, exist_ok=True)\n",
+    "print('Processing {} to {}'.format(base_task_name, output_base))\n",
+    "\n",
+    "options.api_output_file = sequence_smoothed_classification_file\n",
+    "options.output_dir = output_base\n",
+    "ppresults = process_batch_results(options)\n",
+    "path_utils.open_file(ppresults.output_html_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eac5c71",
    "metadata": {},
    "source": [
     "## Zip .json files"
@@ -1481,7 +2096,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b83a491",
+   "id": "9ed31d59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1494,11 +2109,16 @@
     "\n",
     "output_path = combined_api_output_folder\n",
     "\n",
-    "def zip_json_file(fn):\n",
+    "def zip_json_file(fn, overwrite=False):\n",
     "\n",
     "    assert fn.endswith('.json')\n",
     "    basename = os.path.basename(fn)\n",
     "    zip_file_name = os.path.join(output_path,basename + '.zip')\n",
+    "\n",
+    "    if (not overwrite) and (os.path.isfile(zip_file_name)):\n",
+    "        print('Skipping existing file {}'.format(zip_file_name))\n",
+    "        return\n",
+    "\n",
     "    print('Zipping {} to {}'.format(fn,zip_file_name))\n",
     "\n",
     "    with ZipFile(zip_file_name,'w',zipfile.ZIP_DEFLATED) as zipf:\n",
@@ -1513,7 +2133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42cf98b3",
+   "id": "b4b20c2d",
    "metadata": {},
    "source": [
     "## 99.9% of jobs end here"
@@ -1522,7 +2142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0b727bf",
+   "id": "321b0cfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1531,7 +2151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86c7be00",
+   "id": "185bb7dc",
    "metadata": {},
    "source": [
     "## Compare results files for different model versions (or before/after RDE)"
@@ -1540,7 +2160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7983c01e",
+   "id": "a842b73f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1549,6 +2169,14 @@
     "from api.batch_processing.postprocessing.compare_batch_results import (\n",
     "    BatchComparisonOptions,PairwiseBatchComparisonOptions,compare_batch_results)\n",
     "\n",
+    "options = BatchComparisonOptions()\n",
+    "\n",
+    "options.job_name = organization_name_short\n",
+    "options.output_folder = os.path.join(postprocessing_output_folder,'model_comparison')\n",
+    "options.image_folder = input_path\n",
+    "\n",
+    "options.pairwise_options = []\n",
+    "\n",
     "filenames = [\n",
     "    '/postprocessing/organization/mdv4_results.json',\n",
     "    '/postprocessing/organization/mdv5a_results.json',\n",
@@ -1556,15 +2184,6 @@
     "    ]\n",
     "\n",
     "detection_thresholds = [0.7,0.15,0.15]\n",
-    "detection_threshold_string = '_'.join(map(str,detection_thresholds))\n",
-    "\n",
-    "options = BatchComparisonOptions()\n",
-    "\n",
-    "options.job_name = organization_name_short\n",
-    "options.image_folder = input_path\n",
-    "options.pairwise_options = []\n",
-    "options.output_folder = os.path.join(postprocessing_output_folder,'model_comparison_' + \\\n",
-    "                                     detection_threshold_string)\n",
     "\n",
     "assert len(detection_thresholds) == len(filenames)\n",
     "\n",
@@ -1597,7 +2216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "003702e9",
+   "id": "59ff0242",
    "metadata": {},
    "source": [
     "## Merge in high-confidence detections from another results file"
@@ -1606,7 +2225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1fbedb2",
+   "id": "948f83e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1628,7 +2247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c7239d2",
+   "id": "d1b03fb1",
    "metadata": {},
    "source": [
     "## Create a new category for large boxes"
@@ -1637,7 +2256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de0d640d",
+   "id": "caebdfa1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1660,7 +2279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dcf5a35b",
+   "id": "a4907820",
    "metadata": {},
    "source": [
     "## Preview large boxes"
@@ -1669,7 +2288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1feb803",
+   "id": "0aacced3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1688,7 +2307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f6fb1e0",
+   "id": "6a883223",
    "metadata": {},
    "source": [
     "## .json splitting"
@@ -1697,7 +2316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8c247e9",
+   "id": "0ebf521b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1735,7 +2354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa0dd5ce",
+   "id": "10aea2cc",
    "metadata": {},
    "source": [
     "## Custom splitting/subsetting"
@@ -1744,7 +2363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "534bc7a0",
+   "id": "5a1bdbb8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1784,7 +2403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9f77fc8",
+   "id": "5af0372f",
    "metadata": {},
    "source": [
     "## String replacement"
@@ -1793,7 +2412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "197eb029",
+   "id": "d7f50604",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1813,7 +2432,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81cc3a75",
+   "id": "28f4994b",
    "metadata": {},
    "source": [
     "## Splitting images into folders"
@@ -1822,7 +2441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a35cdce2",
+   "id": "4b4da727",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1837,7 +2456,7 @@
     "options.results_file = filtered_output_filename\n",
     "options.base_input_folder = input_path\n",
     "options.base_output_folder = os.path.join(base_output_folder,folder_name)\n",
-    "options.n_threads = 100\n",
+    "options.n_threads = default_workers_for_parallel_tasks\n",
     "options.allow_existing_directory = False\n",
     "\n",
     "separate_detections_into_folders(options)"
@@ -1845,7 +2464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b7fd734",
+   "id": "0b39c708",
    "metadata": {},
    "source": [
     "## Generate commands for a subset of tasks"
@@ -1854,7 +2473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a283052",
+   "id": "1b1ee03f",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/api/batch_processing/data_preparation/manage_local_batch.py
+++ b/api/batch_processing/data_preparation/manage_local_batch.py
@@ -1989,7 +1989,7 @@ os.chmod(cmd_file, st.st_mode | stat.S_IEXEC)
 import os
 import nbformat as nbf
 
-input_py_file = os.path.expanduser('~/git/CameraTraps/api/batch_processing/data_preparation/manage_local_batch.py')
+input_py_file = os.path.expanduser('~/git/cameratraps/api/batch_processing/data_preparation/manage_local_batch.py')
 assert os.path.isfile(input_py_file)
 output_ipynb_file = input_py_file.replace('.py','.ipynb')
 

--- a/api/batch_processing/postprocessing/add_max_conf.py
+++ b/api/batch_processing/postprocessing/add_max_conf.py
@@ -1,0 +1,56 @@
+#
+# add_max_conf.py
+#
+# The MD output format included a "max_detection_conf" field with each image
+# up to and including version 1.2; it was removed as of version 1.3 (it's
+# redundant with the individual detection confidence values).
+#
+# Just in case someone took a dependency on that field, this script allows you
+# to add it back to an existing .json file.
+#
+
+#%% Imports and constants
+
+import os
+import json
+import ct_utils
+
+
+#%% Main function
+
+def add_max_conf(input_file,output_file):
+    
+    assert os.path.isfile(input_file), "Can't find input file {}".format(input_file)
+    
+    with open(input_file,'r') as f:
+        d = json.load(f)
+        
+    for im in d['images']:
+        
+        max_conf = ct_utils.get_max_conf(im)
+        
+        if 'max_detection_conf' in im:
+            assert abs(max_conf - im['max_detection_conf']) < 0.00001
+        else:
+            im['max_detection_conf'] = max_conf
+            
+    with open(output_file,'w') as f:
+        json.dump(d,f,indent=1)
+    
+
+#%% Driver
+
+import argparse
+
+def main():
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file',type=str,
+                        help='Input .json file')
+    parser.add_argument('output_file',type=str,
+                        help='Output .json file')
+    args = parser.parse_args()
+    add_max_conf(args.input_file, args.output_file)
+
+if __name__ == '__main__':
+    main()

--- a/api/batch_processing/postprocessing/merge_detections.py
+++ b/api/batch_processing/postprocessing/merge_detections.py
@@ -184,9 +184,10 @@ def merge_detections(source_files,target_file,output_file,options=None):
                 detections = fn_to_image[image_filename]['detections']                
                 detections.extend(detections_to_transfer)
 
-                # Update the max_detection_conf field
-                fn_to_image[image_filename]['max_detection_conf'] = \
-                    max([d['conf'] for d in detections])
+                # Update the max_detection_conf field (if present)
+                if 'max_detection_conf' in fn_to_image[image_filename]:
+                    fn_to_image[image_filename]['max_detection_conf'] = \
+                        max([d['conf'] for d in detections])
                 
         # ...for each image
         

--- a/api/batch_processing/postprocessing/repeat_detection_elimination/repeat_detections_core.py
+++ b/api/batch_processing/postprocessing/repeat_detection_elimination/repeat_detections_core.py
@@ -827,7 +827,8 @@ def find_repeat_detections(inputFilename, outputFilename=None, options=None):
         os.makedirs(options.outputBase,exist_ok=True)
 
 
-    # Load file
+    # Load file to a pandas dataframe.  Also populates 'max_detection_conf', even if it's
+    # not present in the .json file.
 
     detectionResults, otherFields = load_api_results(inputFilename, normalize_paths=True,
                                          filename_replacements=options.filenameReplacements)

--- a/api/batch_processing/postprocessing/separate_detections_into_folders.py
+++ b/api/batch_processing/postprocessing/separate_detections_into_folders.py
@@ -82,11 +82,10 @@ import itertools
 
 from multiprocessing.pool import ThreadPool
 from functools import partial
-from detection.run_detector import get_detector_metadata_from_version_string        
-from detection.run_detector import get_detector_version_from_filename
 from tqdm import tqdm
 
 from ct_utils import args_to_object
+from detection.run_detector import get_typical_confidence_threshold_from_results
 
 import visualization.visualization_utils as viz_utils
 
@@ -434,22 +433,9 @@ def separate_detections_into_folders(options):
     
     default_threshold = options.threshold
     
-    if default_threshold is None:
+    if default_threshold is None:        
+        default_threshold = get_typical_confidence_threshold_from_results(results)        
         
-        if 'detector_metadata' in results['info'] and \
-            'typical_detection_threshold' in results['info']['detector_metadata']:
-            default_threshold = results['info']['detector_metadata']['typical_detection_threshold']
-        elif ('detector' not in results['info']) or (results['info']['detector'] is None):
-            print('Warning: detector version not available in results file, using MDv5 defaults')
-            detector_metadata = get_detector_metadata_from_version_string('v5a.0.0')
-            default_threshold = detector_metadata['typical_detection_threshold']
-        else:
-            print('Warning: detector metadata not available in results file, inferring from MD version')
-            detector_filename = results['info']['detector']
-            detector_version = get_detector_version_from_filename(detector_filename)
-            detector_metadata = get_detector_metadata_from_version_string(detector_version)
-            default_threshold = detector_metadata['typical_detection_threshold']
-    
     detection_categories = results['detection_categories']    
     options.detection_categories = detection_categories
     options.category_id_to_category_name = detection_categories

--- a/api/batch_processing/postprocessing/subset_json_detector_output.py
+++ b/api/batch_processing/postprocessing/subset_json_detector_output.py
@@ -62,6 +62,7 @@ import re
 from tqdm import tqdm
 
 from ct_utils import args_to_object
+from ct_utils import get_max_conf
 
 
 #%% Helper classes
@@ -168,7 +169,7 @@ def subset_json_detector_output_by_confidence(data, options):
         if ('detections' not in im) or (im['detections'] is None):
             continue
         
-        p_orig = im['max_detection_conf']
+        p_orig = get_max_conf(im)
 
         # Find all detections above threshold for this image
         detections = [d for d in im['detections'] if d['conf'] >= options.confidence_threshold]
@@ -193,7 +194,9 @@ def subset_json_detector_output_by_confidence(data, options):
             # We should only be *lowering* max confidence values (i.e., making them negative)
             assert (p_orig <= 0) or (p < p_orig), 'Confidence changed from {} to {}'.format(p_orig, p)
             n_max_changes += 1
-        im['max_detection_conf'] = p
+        
+        if 'max_detection_conf' in im:
+            im['max_detection_conf'] = p
         images_out.append(im)
         
     # ...for each image        

--- a/classification/merge_classification_detection_output.py
+++ b/classification/merge_classification_detection_output.py
@@ -307,7 +307,6 @@ def process_queried_images(
             elif img_path not in images:
                 images[img_path] = {
                     'file': img_path,
-                    'max_detection_conf': 1.0,
                     'detections': [
                         {
                             'category': cat_to_catid[bbox_dict['category']],

--- a/ct_utils.py
+++ b/ct_utils.py
@@ -214,3 +214,23 @@ def get_iou(bb1, bb2):
     assert iou >= 0.0, 'Illegal IOU < 0'
     assert iou <= 1.0, 'Illegal IOU > 1'
     return iou
+
+
+def _get_max_conf_from_detections(detections):
+    max_conf = 0.0
+    if detections is not None and len(detections) > 0:
+        confidences = [det['conf'] for det in detections]
+        max_conf = max(confidences)
+    return max_conf
+    
+def get_max_conf(im):
+    """
+    Given an image dict in the format used by the batch API, compute the maximum detection
+    confidence for any class.  Returns 0.0 (not None) if there was a failure and 'detections'
+    isn't present.
+    """
+    
+    max_conf = 0.0
+    if 'detections' in im and im['detections'] is not None and len(im['detections']) > 0:
+        max_conf = _get_max_conf_from_detections(im['detections'])
+    return max_conf

--- a/data_management/cct_to_md.py
+++ b/data_management/cct_to_md.py
@@ -108,7 +108,9 @@ def cct_to_md(input_filename,output_filename=None):
         # ...for each annotation
         
         im_out['detections'] = detections
-        im_out['max_detection_conf'] = max_detection_conf
+        
+        # This field is no longer included in MD output files by default
+        # im_out['max_detection_conf'] = max_detection_conf
     
         images_out.append(im_out)
         

--- a/data_management/yolo_output_to_md_output.py
+++ b/data_management/yolo_output_to_md_output.py
@@ -90,7 +90,6 @@ def yolo_output_to_md_output(input_results_folder,input_image_folder,output_file
                 
         images_entries.append({
             'file': image_fn,
-            'max_detection_conf': max_conf,
             'detections': detections
         })
     
@@ -107,7 +106,7 @@ def yolo_output_to_md_output(input_results_folder,input_image_folder,output_file
         'info': {
             'detector': detector_string,
             'detector_metadata': {},
-            'format_version': '1.2'
+            'format_version': '1.3'
         },
         'detection_categories': {
             '1': 'animal',

--- a/detection/process_video.py
+++ b/detection/process_video.py
@@ -351,7 +351,10 @@ if False:
             # ...for each detection
             
             im['detections'] = valid_detections
-            im['max_detection_conf'] = max_detection_conf
+            
+            # This is no longer included in output files by default
+            if 'max_detection_conf' in im:
+                im['max_detection_conf'] = max_detection_conf
             
         print('Kept {} of {} detections (min conf {})'.format(
             n_valid_detections,n_detections,min_valid_confidence))

--- a/detection/pytorch_detector.py
+++ b/detection/pytorch_detector.py
@@ -74,7 +74,7 @@ class PTDetector:
         Returns:
         A dict with the following fields, see the 'images' key in https://github.com/microsoft/CameraTraps/tree/master/api/batch_processing#batch-processing-api-output-format
             - 'file' (always present)
-            - 'max_detection_conf'
+            - 'max_detection_conf' (removed from MegaDetector output by default, but generated here)
             - 'detections', which is a list of detection objects containing keys 'category', 
               'conf' and 'bbox'
             - 'failure'

--- a/detection/run_detector.py
+++ b/detection/run_detector.py
@@ -114,7 +114,7 @@ DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD = 0.005
 
 DEFAULT_BOX_THICKNESS = 4
 DEFAULT_BOX_EXPANSION = 0
-
+    
 
 #%% Classes
 
@@ -223,6 +223,28 @@ def get_detector_version_from_filename(detector_filename):
     else:
         return known_model_versions[matches[0]]
     
+
+def get_typical_confidence_threshold_from_results(results):
+    """
+    Given the .json data loaded from a MD results file, determine a typical confidence
+    threshold based on the detector version.
+    """
+    if 'detector_metadata' in results['info'] and \
+        'typical_detection_threshold' in results['info']['detector_metadata']:
+        default_threshold = results['info']['detector_metadata']['typical_detection_threshold']
+    elif ('detector' not in results['info']) or (results['info']['detector'] is None):
+        print('Warning: detector version not available in results file, using MDv5 defaults')
+        detector_metadata = get_detector_metadata_from_version_string('v5a.0.0')
+        default_threshold = detector_metadata['typical_detection_threshold']
+    else:
+        print('Warning: detector metadata not available in results file, inferring from MD version')
+        detector_filename = results['info']['detector']
+        detector_version = get_detector_version_from_filename(detector_filename)
+        detector_metadata = get_detector_metadata_from_version_string(detector_version)
+        default_threshold = detector_metadata['typical_detection_threshold']
+
+    return default_threshold    
+
     
 def is_gpu_available(model_file):
     """Decide whether a GPU is available, importing PyTorch or TF depending on the extension

--- a/detection/video_utils.py
+++ b/detection/video_utils.py
@@ -332,10 +332,13 @@ def frame_results_to_video_results(input_file,output_file,options:FrameToVideoOp
         im_out = {}
         im_out['file'] = video_name
         im_out['detections'] = canonical_detections
-        im_out['max_detection_conf'] = 0
-        if len(canonical_detections) > 0:
-            confidences = [d['conf'] for d in canonical_detections]
-            im_out['max_detection_conf'] = max(confidences)
+        
+        # 'max_detection_conf' is no longer included in output files by default
+        if False:
+            im_out['max_detection_conf'] = 0
+            if len(canonical_detections) > 0:
+                confidences = [d['conf'] for d in canonical_detections]
+                im_out['max_detection_conf'] = max(confidences)
         
         output_images.append(im_out)
         


### PR DESCRIPTION
The MD output format has always had a "max_detection_conf" field on each image, which is redundant with the individual detection values.  This has created no fewer than 10 bugs (hopefully all fixed) over the last few years when these somehow got out of sync, so I'm finally removing this field, and rev'ing the format version number from 1.2 to 1.3.  Timelapse does not depend on this field, and all of the tools within this repo that used to depend on this field no longer do.  This field can still be generated by run_detector_batch.py with the --include_max_conf option.