### PR TITLE
Update visualize_detector_output.py

### DIFF
--- a/visualization/visualize_detector_output.py
+++ b/visualization/visualize_detector_output.py
@@ -244,7 +244,7 @@ def main() -> None:
     visualize_detector_output(
         detector_output_path=args.detector_output_path,
         out_dir=args.out_dir,
-        confidence=args.confidence,
+        confidence_threshold=args.confidence,
         images_dir=args.images_dir,
         is_azure=args.is_azure,
         sample=args.sample,


### PR DESCRIPTION
Mismatch of arguments between:

- `confidence_threshold` in the function `visualize_detector_output`
- `confidence` when calling `visualize_detector_output` in the `main` function

This lead to the following error:

TypeError: visualize_detector_output() got an unexpected keyword argument 'confidence'