### PR TITLE
Reducing Image Size and Improving Efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ ARG GRADIO_SERVER_PORT="80"
 ENV GRADIO_SERVER_PORT=${GRADIO_SERVER_PORT}  
       
 RUN apt-get update && \    
-    apt-get install -y libgl1-mesa-glx libglib2.0-0 && \ 
-    apt-get install -y ffmpeg && \
+    apt-get install -y --no-install-recommends  \ 
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    ffmpeg && \
     apt-get clean && \    
     rm -rf /var/lib/apt/lists/* 
     
@@ -18,7 +20,7 @@ COPY . /app
      
 RUN rm -rf /tmp/*    
     
-RUN pip install PytorchWildlife
-  
+RUN pip install --no-cache-dir PytorchWildlife
+
 EXPOSE 80
 


### PR DESCRIPTION
Change: Added --no-install-recommends to the apt-get install command. This prevents unnecessary additional packages from being installed.
Why: It reduces the image size by skipping optional components that aren't needed for the application.

Change: Combined apt-get update, installation, cleaning, and removal of temporary files into a single RUN command.
Why: Each RUN command creates a new layer in the Docker image. Combining them minimizes the total number of layers, making the image more efficient.

Change: Used pip install --no-cache-dir when installing Python dependencies.
Why: This prevents pip from caching installation files, which reduces the image size.