### PR TITLE
Fix typos with codespell

### DIFF
--- a/PW_FT_detection/README.md
+++ b/PW_FT_detection/README.md
@@ -81,7 +81,7 @@ Before training your model, you need to configure the training and data paramete
 
 - **General Parameters:**  
   - `model`: The type of model used (YOLO or RTDETR). Default: YOLO  
-  - `model_name`: The name of the model [see availbale names here](#detection-models-available-for-finetuning). Default: MDV6-yolov9-e.pt  
+  - `model_name`: The name of the model [see available names here](#detection-models-available-for-finetuning). Default: MDV6-yolov9-e.pt  
   - `data`: Path to the dataset configuration file. Default: ./data/data_example.yaml  
   - `test_data`: Path to the test data directory. Default: ./data/data_example/images/test  
   - `task`: The task to perform (train, validation or inference). Default: train  
@@ -121,7 +121,7 @@ This command will initiate the training process based on the parameters specifie
 
 ## Output
 
-Once training is complete, the output weights will be saved in the `./runs/detect` directory acoording to the experiment name you configured in the `config.yaml`. These weights can be used to classify new images using [Pytorch-Wildlife](https://github.com/microsoft/CameraTraps/).
+Once training is complete, the output weights will be saved in the `./runs/detect` directory according to the experiment name you configured in the `config.yaml`. These weights can be used to classify new images using [Pytorch-Wildlife](https://github.com/microsoft/CameraTraps/).
 
 We are working on adding a feature in a future release to directly integrate the output weights with the Pytorch-Wildlife framework and the Gradio App.
 

--- a/PytorchWildlife/data/datasets.py
+++ b/PytorchWildlife/data/datasets.py
@@ -85,7 +85,7 @@ class DetectionCrops(Dataset):
         self.detection_results = detection_results
         self.transform = transform
         self.path_head = path_head
-        self.animal_cls_id = animal_cls_id # This determins which detection class id represents animals.
+        self.animal_cls_id = animal_cls_id # This determines which detection class id represents animals.
         self.img_ids = []
         self.xyxys = []
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ There may be a confusion because YOLOv5 was initially released before the establ
 <!-- > [!IMPORTANT]
 > THIS IS TRUE TO ALL EXISTING MEGADETECTORV5 MODELS IN ALL EXISTING FORKS THAT ARE TRAINED USING YOLOV5, AN ULTRALYTICS-DEVELOPED MODEL. -->
 
-We want to make Pytorch-Wildlife a platform where different models with different licenses can be hosted and want to enable different use cases. To reduce user confusions, in our [model zoo](#mag-model-zoo-and-release-schedules) section, we list all existing and planed future models in our model zoo, their corresponding license, and release schedules. 
+We want to make Pytorch-Wildlife a platform where different models with different licenses can be hosted and want to enable different use cases. To reduce user confusions, in our [model zoo](#mag-model-zoo-and-release-schedules) section, we list all existing and planned future models in our model zoo, their corresponding license, and release schedules. 
 
 In addition, since the **Pytorch-Wildlife** package is under MIT, all the utility functions, including data pre-/post-processing functions and model fine-tuning functions in this packages are under MIT as well.
 

--- a/demo/image_demo_herdnet.py
+++ b/demo/image_demo_herdnet.py
@@ -19,7 +19,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 #%% 
 # Initializing the HerdNet model for image detection
 detection_model = pw_detection.HerdNet(device=DEVICE)
-# If you want to use ennedi dataset weigths, you can use the following line:
+# If you want to use ennedi dataset weights, you can use the following line:
 # detection_model = pw_detection.HerdNet(device=DEVICE, version="ennedi")
 
 #%% Single image detection

--- a/demo/image_detection_demo_herdnet.ipynb
+++ b/demo/image_detection_demo_herdnet.ipynb
@@ -61,7 +61,7 @@
     "DEVICE = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     "# Model arguments and initialization\n",
     "detection_model = pw_detection.HerdNet(device=DEVICE)\n",
-    "# If you want to use ennedi dataset weigths, you can use the following line:\n",
+    "# If you want to use ennedi dataset weights, you can use the following line:\n",
     "# detection_model = pw_detection.HerdNet(device=DEVICE, version=\"ennedi\")"
    ]
   },

--- a/megadetector.md
+++ b/megadetector.md
@@ -83,7 +83,7 @@ There may be a confusion because YOLOv5 was initially released before the establ
 <!-- > [!IMPORTANT]
 > THIS IS TRUE TO ALL EXISTING MEGADETECTORV5 MODELS IN ALL EXISTING FORKS THAT ARE TRAINED USING YOLOV5, AN ULTRALYTICS-DEVELOPED MODEL. -->
 
-We want to make Pytorch-Wildlife a platform where different models with different licenses can be hosted and want to enable different use cases. To reduce user confusions, in our [model zoo](#mag-model-zoo-and-release-schedules) section, we list all existing and planed future models in our model zoo, their corresponding license, and release schedules. 
+We want to make Pytorch-Wildlife a platform where different models with different licenses can be hosted and want to enable different use cases. To reduce user confusions, in our [model zoo](#mag-model-zoo-and-release-schedules) section, we list all existing and planned future models in our model zoo, their corresponding license, and release schedules. 
 
 In addition, since the **Pytorch-Wildlife** package is under MIT, all the utility functions, including data pre-/post-processing functions and model fine-tuning functions in this packages are under MIT as well.
 


### PR DESCRIPTION
Saw some typos in the herdnet code so ran [codespell](https://github.com/codespell-project/codespell): `codespell -w --skip="archive,./assets/PytorchWildlife_Windows_installation_tutorial.pdf"`