### PR TITLE
Fix for #612 original megadetector constructors had invalid version string. 

### DIFF
--- a/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
+++ b/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
@@ -20,7 +20,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-rtdetr-x-apache'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-apa-rtdetr-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'MDV6-rtdetr-x-apache'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-apa-rtdetr-c'.
         """
         self.IMAGE_SIZE = 640
 

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
@@ -20,7 +20,7 @@ class MegaDetectorV6(YOLOV8Base):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6(YOLOV8Base):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'yolov9c'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c'.
         """
         self.IMAGE_SIZE = 1280
 

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
@@ -20,7 +20,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'yolov9c'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c'.
         """
         self.IMAGE_SIZE = 1280
 

--- a/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
+++ b/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
@@ -20,7 +20,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c-mit'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-mit-yolov9-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         
@@ -28,7 +28,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
             weights (str, optional): Path to the weights file.
             device (str, optional): Device to load the model on (e.g., "cpu" or "cuda"). Default is "cpu".
             pretrained (bool, optional): Whether to load the pretrained model. Default is True.
-            version (str, optional): Version of the model to load. Default is 'MDV6-yolov9-c-mit'.
+            version (str, optional): Version of the model to load. Default is 'MDV6-mit-yolov9-c'.
         """
         self.IMAGE_SIZE = 640
 


### PR DESCRIPTION

Fixes #612 

Default version string in the init for MegaDetectorV6MIT, MegaDetectorV6_Distributed, MegaDetectorV6, MegaDetectorV6Apache were incorrect.

I updated the default to match the first value in the if else statement which selects the correct weights. Apache version was -x which as far as I can see does not exist so I followed the pattern for the rest and set the default as the first value in the if else string