### PR TITLE
Fix batch classification TypeError when using data_path (#611)

### DIFF
--- a/PytorchWildlife/data/datasets.py
+++ b/PytorchWildlife/data/datasets.py
@@ -14,6 +14,7 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 # Making the DetectionImageFolder class available for import from this module
 __all__ = [
+    "ClassificationImageFolder",
     "DetectionImageFolder",
     ]
 

--- a/PytorchWildlife/models/classification/resnet_base/base_classifier.py
+++ b/PytorchWildlife/models/classification/resnet_base/base_classifier.py
@@ -158,10 +158,9 @@ class PlainResNetInference(BaseClassifierInference):
         """
 
         if data_path:
-            dataset = pw_data.ImageFolder(
+            dataset = pw_data.ClassificationImageFolder(
                 data_path,
                 transform=self.transform,
-                path_head='.'
             )
         elif det_results:
             dataset = pw_data.DetectionCrops(

--- a/PytorchWildlife/models/classification/timm_base/base_classifier.py
+++ b/PytorchWildlife/models/classification/timm_base/base_classifier.py
@@ -177,10 +177,9 @@ class TIMM_BaseClassifierInference(BaseClassifierInference):
         """
 
         if data_path:
-            dataset = pw_data.ImageFolder(
+            dataset = pw_data.ClassificationImageFolder(
                 data_path,
                 transform=self.transform,
-                path_head='.'
             )
         elif det_results:
             dataset = pw_data.DetectionCrops(


### PR DESCRIPTION
Fixes #611

### Problem

Calling `batch_image_classification(data_path=...)` on any TIMM-based or ResNet-based classifier raises a `TypeError` because `pw_data.ImageFolder` does not accept a `path_head` keyword argument:

```python
# Both timm_base and resnet_base had this:
dataset = pw_data.ImageFolder(
    data_path,
    transform=self.transform,
    path_head='.'        # ← ImageFolder doesn't accept this
)
```

Additionally, `ImageFolder` is the abstract base class whose `__getitem__` returns `None`, so even if the kwarg issue were fixed, the dataloader would fail to unpack `(img, img_path)`.

### Fix

- Replace `pw_data.ImageFolder` with `pw_data.ClassificationImageFolder` — the correct subclass that implements `__getitem__` returning `(img, img_path)`.
- Remove the invalid `path_head='.'` argument (`ClassificationImageFolder` builds full paths via `os.walk`, so `path_head` is unnecessary).
- Add `ClassificationImageFolder` to `__all__` in `datasets.py` for export consistency.

### Files changed

| File | Change |
|---|---|
| `PytorchWildlife/data/datasets.py` | Added `ClassificationImageFolder` to `__all__` |
| `PytorchWildlife/models/classification/timm_base/base_classifier.py` | `ImageFolder` → `ClassificationImageFolder`, removed `path_head` |
| `PytorchWildlife/models/classification/resnet_base/base_classifier.py` | Same fix |

### Safety

- The `det_results` code path (using `DetectionCrops`) is **untouched** — `path_head` is valid there.
- No other file in the repo references `pw_data.ImageFolder`.
- All detectors already use `DetectionImageFolder` correctly.
- The broken code path could never have worked, so this is purely additive — no existing working behavior changes.