### PR TITLE
Fix: Add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'setuptools',
         'scikit-learn',
         'timm',
+        'omegaconf',
+        'lightning',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',  


### PR DESCRIPTION
## Summary
Fixes #614

This PR adds two missing requirements that are necessary for the package to work correctly when installed fresh:
- `omegaconf`
- `lightning`

## Changes
- Added `omegaconf` to `install_requires` in setup.py
- Added `lightning` to `install_requires` in setup.py

## Rationale
These dependencies are used by the detection and classification models but were missing from setup.py (they exist in requirements.txt). When users install the package from setup.py in a fresh environment, they encounter ImportError failures.

## Testing
The fix has been tested to ensure the package structure is valid. The changes are minimal and directly address the reported issue.