### PR TITLE
Fix: Correct megadetector version string initialization

### DIFF
--- a/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
+++ b/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
@@ -20,7 +20,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-rtdetr-x-apache'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-apa-rtdetr-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
@@ -20,7 +20,7 @@ class MegaDetectorV6(YOLOV8Base):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
@@ -20,7 +20,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
+++ b/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
@@ -20,7 +20,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c-mit'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-mit-yolov9-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         


### PR DESCRIPTION
Fixes #612

## Problem
The default version strings for MegaDetectorV6, MegaDetectorV6_Distributed, MegaDetectorV6MIT, and MegaDetectorV6Apache were incorrect and did not match the valid versions accepted by their __init__ methods. This caused a ValueError when instantiating these classes without explicitly passing a version string.

## Solution
Corrected the default version strings to match the valid versions in each class:
- **MegaDetectorV6**: 'yolov9c' → 'MDV6-yolov9-c'
- **MegaDetectorV6_Distributed**: 'yolov9c' → 'MDV6-yolov9-c'
- **MegaDetectorV6MIT**: 'MDV6-yolov9-c-mit' → 'MDV6-mit-yolov9-c'
- **MegaDetectorV6Apache**: 'MDV6-rtdetr-x-apache' → 'MDV6-apa-rtdetr-c'

## Changes
- Fixed 4 files with incorrect default version strings
- Each default now matches one of the valid versions in the if-else statements
- No other code changes required

## Testing
Users can now instantiate models without passing an explicit version:
```python
from PytorchWildlife.models import detection as pw_detection

detection_model = pw_detection.MegaDetectorV6(device='cuda', pretrained=True)
detection_model = pw_detection.MegaDetectorV6MIT(device='cuda', pretrained=True)
detection_model = pw_detection.MegaDetectorV6Apache(device='cuda', pretrained=True)
detection_model = pw_detection.MegaDetectorV6_Distributed(device='cuda', pretrained=True)
```