### PR TITLE
Fix: Add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'setuptools',
         'scikit-learn',
         'timm',
+        'omegaconf',
+        'lightning',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',  


### PR DESCRIPTION
Fixes #614

## Changes
- Added omegaconf to setup.py install_requires
- Added lightning to setup.py install_requires

## Why
These dependencies are in requirements.txt but missing from setup.py, causing fresh installations to fail.

## Testing
- Verified setup.py syntax
- All dependencies now match requirements.txt