### PR TITLE
Fix: Correct megadetector version string initialization

### DIFF
--- a/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
+++ b/PytorchWildlife/models/detection/rtdetr_apache/megadetectorv6_apache.py
@@ -20,7 +20,7 @@ class MegaDetectorV6Apache(RTDETRApacheBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-rtdetr-x-apache'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-apa-rtdetr-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6.py
@@ -20,7 +20,7 @@ class MegaDetectorV6(YOLOV8Base):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/megadetectorv6_distributed.py
@@ -20,7 +20,7 @@ class MegaDetectorV6_Distributed(YOLOV8_Distributed):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='yolov9c'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c'):
         """
         Initializes the MegaDetectorV5 model with the option to load pretrained weights.
         

--- a/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
+++ b/PytorchWildlife/models/detection/yolo_mit/megadetectorv6_mit.py
@@ -20,7 +20,7 @@ class MegaDetectorV6MIT(YOLOMITBase):
         2: "vehicle"
     }
 
-    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-yolov9-c-mit'):
+    def __init__(self, weights=None, device="cpu", pretrained=True, version='MDV6-mit-yolov9-c'):
         """
         Initializes the MegaDetectorV6 model with the option to load pretrained weights.
         


### PR DESCRIPTION
Fixes #612

## Changes
Fixed invalid version string defaults in:
- MegaDetectorV6: 'yolov9c' → 'MDV6-yolov9-c'
- MegaDetectorV6_Distributed: 'yolov9c' → 'MDV6-yolov9-c'
- MegaDetectorV6MIT: 'MDV6-yolov9-c-mit' → 'MDV6-mit-yolov9-c'
- MegaDetectorV6Apache: 'MDV6-rtdetr-x-apache' → 'MDV6-apa-rtdetr-c'

## Why
Default version strings didn't match the valid versions in their if-else conditions, causing ValueError when instantiating without explicit version parameter.

## Testing
- Verified version strings match valid options in code
- All changes compile without errors