### PR TITLE
🚀 Feature: Add SpeciesNet classification model implementation

### DIFF
--- a/PytorchWildlife/models/classification/__init__.py
+++ b/PytorchWildlife/models/classification/__init__.py
@@ -1,3 +1,4 @@
 from .resnet_base import *
 from .timm_base import *
 from .base_classifier import *
+from .speciesnet import *

--- a/PytorchWildlife/models/classification/speciesnet.py
+++ b/PytorchWildlife/models/classification/speciesnet.py
@@ -1,0 +1,42 @@
+import timm
+import torch.nn as nn
+
+from .base_classifier import BaseClassifier
+
+
+class SpeciesNet(BaseClassifier):
+    """SpeciesNet classification model using a ResNet‑50 backbone.
+
+    This model follows the same interface as other classification models in the
+    library, allowing it to be instantiated via the configuration system and
+    used interchangeably with existing models.
+    """
+
+    def __init__(self, num_cls, pretrained=True, **kwargs):
+        """Create a ResNet‑50 model with a custom classification head.
+
+        Args:
+            num_cls (int): Number of output classes.
+            pretrained (bool, optional): Whether to load ImageNet‑pretrained
+                weights for the backbone. Defaults to True.
+            **kwargs: Additional keyword arguments passed to ``timm.create_model``.
+        """
+        super().__init__()
+        # ``timm`` handles the creation of the backbone and the classification head.
+        self.backbone = timm.create_model(
+            "resnet50", pretrained=pretrained, num_classes=num_cls, **kwargs
+        )
+
+    def forward(self, x):
+        """Forward pass through the ResNet‑50 backbone.
+
+        Args:
+            x (torch.Tensor): Input batch of images.
+
+        Returns:
+            torch.Tensor: Logits for each class.
+        """
+        return self.backbone(x)
+
+
+__all__ = ["SpeciesNet"]


### PR DESCRIPTION
## Problem

Introduce a new SpeciesNet model that follows the same interface as the other classification models in the library. The model will be a thin PyTorch wrapper around a ResNet‑50 backbone (using timm) with a custom classification head that matches the expected number of classes. The implementation inherits from the existing `BaseClassifier` so it can be used interchangeably with the other models (e.g., Amazon, Serengeti) throughout the Pytorch‑Wildlife code‑base.

**Severity**: `medium`
**File**: `PytorchWildlife/models/classification/speciesnet.py`

## Solution

Implemented the necessary changes to address the identified issue in `PytorchWildlife/models/classification/speciesnet.py`.

## Changes

- `PytorchWildlife/models/classification/speciesnet.py` (new)
- `PytorchWildlife/models/classification/__init__.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #597