### PR TITLE
Quality: GPU configuration crash on CPU-only systems

### DIFF
--- a/PW_FT_classification/main.py
+++ b/PW_FT_classification/main.py
@@ -56,7 +56,22 @@ def main(
 
     # GPU configuration: set up GPUs based on availability and user specification
     if torch.cuda.is_available():
-        gpus = [int(i) for i in gpus.split(',')]
+        # Sanitize and validate the GPU list provided via CLI
+        if gpus is None:
+            parsed_gpus = None
+        else:
+            tokens = [token.strip() for token in str(gpus).split(",") if token.strip()]
+            if not tokens:
+                # Empty or whitespace-only input: fall back to CPU
+                parsed_gpus = None
+            else:
+                try:
+                    parsed_gpus = [int(token) for token in tokens]
+                except ValueError as exc:
+                    raise typer.BadParameter(
+                        f"Invalid GPU list '{gpus}'. Expected a comma-separated list of integers, e.g. '0,1,2'."
+                    ) from exc
+        gpus = parsed_gpus
     else:
         # If no CUDA devices are available, set gpus to None to indicate CPU usage
         # PyTorch Lightning Trainer will default to CPU if devices is None

--- a/PW_FT_classification/main.py
+++ b/PW_FT_classification/main.py
@@ -55,8 +55,12 @@ def main(
     """
 
     # GPU configuration: set up GPUs based on availability and user specification
-    gpus = gpus if torch.cuda.is_available() else None
-    gpus = [int(i) for i in gpus.split(',')]
+    if torch.cuda.is_available():
+        gpus = [int(i) for i in gpus.split(',')]
+    else:
+        # If no CUDA devices are available, set gpus to None to indicate CPU usage
+        # PyTorch Lightning Trainer will default to CPU if devices is None
+        gpus = None
 
     # Environment variable setup for numpy multi-threading. It is important to avoid cpu and ram issues.
     os.environ["OMP_NUM_THREADS"] = str(np_threads)


### PR DESCRIPTION
## Problem

The code attempts to process the `gpus` string by splitting it, but `gpus` can become `None` if `torch.cuda.is_available()` returns `False`. This will lead to an `AttributeError` when `gpus.split(',')` is called, causing the application to crash on systems without a GPU or where CUDA is not detected. This makes the application unusable in CPU-only environments.


**Severity**: `critical`
**File**: `PW_FT_classification/main.py`

## Solution

Explicitly handle the case where `gpus` is `None` by assigning an empty list or a CPU-specific device identifier, or by performing the split only if `gpus` is a string.


## Changes

- `PW_FT_classification/main.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
