### PR TITLE
docs(seo): fix nav label, enable tags plugin with browsable index

### DIFF
--- a/archive/pre-seo/docs/bioacoustics.md
+++ b/archive/pre-seo/docs/bioacoustics.md
@@ -1,0 +1,37 @@
+# Bioacoustics
+
+PyTorchWildlife's bioacoustics module provides training, inference, and dataset preparation for audio classification. The module lives at [`PW_Bioacoustics/`](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics) and builds on core APIs in `PytorchWildlife.data.bioacoustics` and `PytorchWildlife.models.bioacoustics`.
+
+## What's included
+
+- **CLI scripts** for dataset preparation (`prepare_dataset.py`), training (`train.py`), and inference (`inference.py`)
+- **`ResNetClassifier`** — PyTorch Lightning module for spectrogram classification (binary and multiclass)
+- **Mel-spectrogram preprocessing** with optional GPU acceleration
+- **Annotation readers** (COCO-like JSON), including support for the PteroSet / Raven Pro format
+- **`MD_AudioBirds_V1`** — a pre-trained bird classifier distributed as ONNX for direct inference
+
+See the [Bioacoustics model zoo](model_zoo/bioacoustics.md) for the released models.
+
+## Demo
+
+The end-to-end notebook at [`PW_Bioacoustics/demo/bioacoustics_demo.ipynb`](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics/demo) walks through:
+
+1. **Data exploration** — annotation counts, species distribution
+2. **Inference** — run `MD_AudioBirds_V1` on real recordings, visualise predictions vs. ground truth
+3. **Training** — build COCO-style annotations, binary classification (target vs. noise), multiclass classification
+
+It uses recordings from the [PteroSet](https://zenodo.org/records/19137071) dataset.
+
+## Projects using this module
+
+- **[PteroSet](https://github.com/microsoft/PteroSet)** — Machine-learning pipeline for detecting and classifying tropical bird vocalisations from passive acoustic monitoring, with leave-one-project-out cross-validation.
+- **[CookInlet_Belugas](https://github.com/microsoft/CookInlet_Belugas)** — Passive acoustic monitoring for endangered Cook Inlet beluga whales. A two-stage pipeline covering cetacean signal detection and multi-species classification (beluga, humpback, killer whale), plus an active-learning loop for domain adaptation.
+
+## Install
+
+```bash
+pip install PytorchWildlife
+pip install librosa soundfile pyyaml torchmetrics
+```
+
+See the [PW_Bioacoustics README](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics) for full configuration options, training arguments, and output formats.

--- a/archive/pre-seo/docs/cite.md
+++ b/archive/pre-seo/docs/cite.md
@@ -1,0 +1,24 @@
+# :fountain_pen: Cite us!
+We have recently published a [summary paper on Pytorch-Wildlife](https://arxiv.org/abs/2405.12930). The paper has been accepted as an oral presentation at the [CV4Animals workshop](https://www.cv4animals.com/) at this CVPR 2024. Please feel free to cite us!
+
+```
+@misc{hernandez2024pytorchwildlife,
+      title={Pytorch-Wildlife: A Collaborative Deep Learning Framework for Conservation}, 
+      author={Andres Hernandez and Zhongqi Miao and Luisa Vargas and Sara Beery and Rahul Dodhia and Juan Lavista},
+      year={2024},
+      eprint={2405.12930},
+      archivePrefix={arXiv},
+}
+```
+
+Also, don't forget to cite our original paper for MegaDetector: 
+
+```
+@misc{beery2019efficient,
+      title={Efficient Pipeline for Camera Trap Image Review},
+      author={Sara Beery and Dan Morris and Siyu Yang},
+      year={2019}
+      eprint={1907.06772},
+      archivePrefix={arXiv},
+}
+```

--- a/archive/pre-seo/docs/collaborators.md
+++ b/archive/pre-seo/docs/collaborators.md
@@ -1,0 +1,79 @@
+ # 👥 Existing Collaborators
+
+The extensive collaborative efforts of Megadetector have genuinely inspired us, and we deeply value its significant contributions to the community. As we continue to advance with Pytorch-Wildlife, our commitment to delivering technical support to our existing partners on MegaDetector remains the same.
+
+Here we list a few of the organizations that have used MegaDetector. We're only listing organizations who have given us permission to refer to them here or have posted publicly about their use of MegaDetector.
+
+<details>
+<summary><font size="3">👉 Full list of organizations</font></summary>
+<ul>
+  <li>(Newly Added) <a href="https://www.terroiko.fr/">TerrOïko</a> (<a href="https://www.terroiko.fr/ocapi">OCAPI platform</a>)</li>
+  <li><a href="http://azdeq.gov/">Arizona Department of Environmental Quality</a></li>
+  <li><a href="https://blackbirdenv.com/">Blackbird Environmental</a></li>
+  <li><a href="https://camelotproject.org/">Camelot</a></li>
+  <li><a href="https://cpawsnab.org/">Canadian Parks and Wilderness Society (CPAWS) Northern Alberta Chapter</a></li>
+  <li><a href="https://conservationxlabs.com/">Conservation X Labs</a></li>
+  <li><a href="https://www.czu.cz/en">Czech University of Life Sciences Prague</a></li>
+  <li><a href="https://www.consult-ecologic.com/">EcoLogic Consultants Ltd.</a></li>
+  <li><a href="http://www.ebd.csic.es/inicio">Estación Biológica de Doñana</a></li>
+  <li><a href="https://idfg.idaho.gov/">Idaho Department of Fish and Game</a></li>
+  <li><a href="https://www.islandconservation.org/">Island Conservation</a></li>
+  <li><a href="https://carnivorecoexistence.info/myall-lakes-dingo-project/">Myall Lakes Dingo Project</a></li>
+  <li><a href="https://pnptc.org/">Point No Point Treaty Council</a></li>
+  <li><a href="https://www.ramat-hanadiv.org.il/en/">Ramat Hanadiv Nature Park</a></li>
+  <li><a href="https://spea.pt/en/">SPEA (Portuguese Society for the Study of Birds)</a></li>
+  <li><a href="https://www.synthetaic.com/">Synthetaic</a></li>
+  <li><a href="https://taronga.org.au/">Taronga Conservation Society</a></li>
+  <li><a href="https://www.nature.org/en-us/about-us/where-we-work/united-states/wyoming/">The Nature Conservancy in Wyoming</a></li>
+  <li><a href="https://wildeyeconservation.org/trap-tagger-about/">TrapTagger</a></li>
+  <li><a href="https://www.upperyellowstone.org/">Upper Yellowstone Watershed Group</a></li>
+  <li><a href="http://www.acmelab.ca/">Applied Conservation Macro Ecology Lab</a>, University of Victoria</li>
+  <li><a href="https://www.pc.gc.ca/en/pn-np/ab/banff/nature/conservation">Banff National Park Resource Conservation</a>, <a href="https://www.pc.gc.ca/en/pn-np/ab/banff/nature/conservation">Parks Canada</a></li>
+  <li><a href="https://blumsteinlab.eeb.ucla.edu/">Blumstein Lab</a>, UCLA</li>
+  <li><a href="https://bri.sulross.edu/">Borderlands Research Institute</a>, Sul Ross State University</li>
+  <li><a href="https://www.nps.gov/care/index.htm">Capitol Reef National Park</a> / Utah Valley University</li>
+  <li><a href="https://www.amnh.org/research/center-for-biodiversity-conservation">Center for Biodiversity and Conservation</a>, American Museum of Natural History</li>
+  <li><a href="https://www.unsw.edu.au/research/">Centre for Ecosystem Science</a>, UNSW Sydney</li>
+  <li><a href="https://crossculturalecology.net/">Cross-Cultural Ecology Lab</a>, Macquarie University</li>
+  <li><a href="https://hub.dccatcount.org/">DC Cat Count</a>, led by the Humane Rescue Alliance</li>
+  <li><a href="https://www.uidaho.edu/cnr/departments/fish-and-wildlife-sciences">Department of Fish and Wildlife Sciences</a>, University of Idaho</li>
+  <li><a href="https://wec.ifas.ufl.edu/">Department of Wildlife Ecology and Conservation</a>, University of Florida</li>
+  <li><a href="https://www.researchgate.net/lab/Fernanda-Michalski-Lab-4">Ecology and Conservation of Amazonian Vertebrates Research Group</a>, Federal University of Amapá</li>
+  <li><a href="https://www.rspb.org.uk/our-work/conservation/projects/scientific-support-for-the-gola-forest-programme/">Gola Forest Programme</a>, Royal Society for the Protection of Birds (RSPB)</li>
+  <li><a href="https://wildliferesearch.co.uk/group-1">Graeme Shannon's Research Group</a>, Bangor University</li>
+  <li><a href="https://hamaarag.org.il/">Hamaarag</a>, The Steinhardt Museum of Natural History, Tel Aviv University</li>
+  <li><a href="https://isfort.uqo.ca/">Institut des Science de la Forêt Tempérée (ISFORT)</a>, Université du Québec en Outaouais</li>
+  <li><a href="https://bhlab.in/about">Lab of Dr. Bilal Habib</a>, the Wildlife Institute of India</li>
+  <li><a href="https://labs.wsu.edu/dthornton/">Mammal Spatial Ecology and Conservation Lab</a>, Washington State University</li>
+  <li><a href="http://mcloughlinlab.ca/lab/">McLoughlin Lab in Population Ecology</a>, University of Saskatchewan</li>
+  <li><a href="https://www.fws.gov/about/region/southwest">National Wildlife Refuge System, Southwest Region</a>, U.S. Fish & Wildlife Service</li>
+  <li><a href="https://nationalzoo.si.edu/news/restoring-americas-prairie">Northern Great Plains Program</a>, Smithsonian</li>
+  <li><a href="https://depts.washington.edu/sefsqel/">Quantitative Ecology Lab</a>, University of Washington</li>
+  <li><a href="https://www.nps.gov/samo/index.htm">Santa Monica Mountains Recreation Area</a>, National Park Service</li>
+  <li><a href="https://www.zoo.org/seattlecarnivores">Seattle Urban Carnivore Project</a>, Woodland Park Zoo</li>
+  <li><a href="https://www.icmbio.gov.br/parnaserradosorgaos/">Serra dos Órgãos National Park</a>, ICMBio</li>
+  <li><a href="https://emammal.si.edu/snapshot-usa">Snapshot USA</a>, Smithsonian</li>
+  <li><a href="https://wildlife.forestry.ubc.ca/">Wildlife Coexistence Lab</a>, University of British Columbia</li>
+  <li><a href="https://www.dfw.state.or.us/wildlife/research/index.asp">Wildlife Research</a>, Oregon Department of Fish and Wildlife</li>
+  <li><a href="https://www.michigan.gov/dnr/about/contact/wildlife">Wildlife Division</a>, Michigan Department of Natural Resources</li>
+  <li>Department of Ecology, TU Berlin</li>
+  <li>Ghost Cat Analytics</li>
+  <li>Protected Areas Unit, Canadian Wildlife Service</li>
+  <li><a href="https://www.utas.edu.au/natural-sciences">School of Natural Sciences</a>, University of Tasmania (<a href="https://www.utas.edu.au/about/news-and-stories/articles/2022/1204-innovative-camera-network-keeps-close-eye-on-tassie-wildlife">story</a>)</li>
+  <li><a href="https://www.fws.gov/refuge/kenai">Kenai National Wildlife Refuge</a>, U.S. Fish & Wildlife Service (<a href="https://www.peninsulaclarion.com/sports/refuge-notebook-new-technology-increases-efficiency-of-refuge-cameras/">story</a>)</li>
+  <li><a href="https://www.australianwildlife.org/">Australian Wildlife Conservancy</a> (<a href="https://www.australianwildlife.org/cutting-edge-technology-delivering-efficiency-gains-in-conservation/">blog</a>, <a href="https://www.australianwildlife.org/efficiency-gains-at-the-cutting-edge-of-technology/">blog</a>)</li>
+  <li><a href="https://felidaefund.org/">Felidae Conservation Fund</a> (<a href="https://wildepod.org/">WildePod platform</a>) (<a href="https://abhaykashyap.com/blog/ai-powered-camera-trap-image-annotation-system/">blog post</a>)</li>
+  <li><a href="https://www.abmi.ca/home.html">Alberta Biodiversity Monitoring Institute (ABMI)</a> (<a href="https://www.wildtrax.ca/">WildTrax platform</a>) (<a href="https://wildcams.ca/blog/the-abmi-visits-the-zoo/">blog post</a>)</li>
+  <li><a href="http://en.shanshui.org/">Shan Shui Conservation Center</a> (<a href="https://mp.weixin.qq.com/s/iOIQF3ckj0-rEG4yJgerYw?fbclid=IwAR0alwiWbe3udIcFvqqwm7y5qgr9hZpjr871FZIa-ErGUukZ7yJ3ZhgCevs">blog post</a>) (<a href="https://mp-weixin-qq-com.translate.goog/s/iOIQF3ckj0-rEG4yJgerYw?fbclid=IwAR0alwiWbe3udIcFvqqwm7y5qgr9hZpjr871FZIa-ErGUukZ7yJ3ZhgCevs&_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">translated blog post</a>)</li>
+  <li><a href="http://www.irconservancy.org/">Irvine Ranch Conservancy</a> (<a href="https://www.ocregister.com/2022/03/30/ai-software-is-helping-researchers-focus-on-learning-about-ocs-wild-animals/">story</a>)</li>
+  <li><a href="https://wildlifeprotectionsolutions.org/">Wildlife Protection Solutions</a> (<a href="https://customers.microsoft.com/en-us/story/1384184517929343083-wildlife-protection-solutions-nonprofit-ai-for-earth">story</a>, <a href="https://www.enterpriseai.news/2023/02/20/ai-helps-wildlife-protection-solutions-safeguard-endangered-species/">story</a>)</li>
+  <li><a href="https://roadecology.ucdavis.edu/">Road Ecology Center</a>, University of California, Davis (<a href="https://wildlifeobserver.net/">Wildlife Observer Network platform</a>)</li>
+  <li><a href="https://www.nature.org/en-us/about-us/where-we-work/united-states/california/">The Nature Conservancy in California</a> (<a href="https://github.com/tnc-ca-geo/animl-frontend">Animl platform</a>)</li>
+  <li><a href="https://science.sandiegozoo.org/">San Diego Zoo Wildlife Alliance</a> (<a href="https://github.com/conservationtechlab/animl">Animl R package</a>)</li>
+</ul>
+
+</details><br>
+
+
+>[!IMPORTANT]
+>If you would like to be added to this list or have any questions regarding MegaDetector and Pytorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our Discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PytorchWildife)](https://discord.gg/TeEVxzaYtm)

--- a/archive/pre-seo/docs/contribute.md
+++ b/archive/pre-seo/docs/contribute.md
@@ -1,0 +1,19 @@
+# 🤝 Contribution Guidelines
+
+Thanks for your interest in collaborating on Pytorch-Wildlife! Here you can find the guidelines on how to contribute 🌱:
+
+## How to participate
+
+1. 💡 Browse our project board: [Pytorch-Wildlife](https://github.com/orgs/microsoft/projects/1833)! 
+2. 📋 Look under the **“Ready”** column for issues/tasks open to contributors.  
+3. 💬 Pick an issue from the **“Ready”** column and add a comment expressing your interest!
+4. 🤝 Once we get your comments, we’ll move the issue to **“In progress”** and assign you as the collaborator.  
+5. 🛠 Work on it at your own pace, and when it’s ready, submit a pull request to the **`Collaborations`** branch. 
+6. 🔍 We’ll review your PR, run tests, and merge it into our **pre‑release** branch ahead of the next version.
+7. 🎉 After merging, we’ll mark the issue/task as **“Done”** and credit your contribution in the release notes—thank you!
+
+---
+
+Thank you for helping us improve PytorchWildlife!
+
+We have adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [us](mailto:zhongqimiao@microsoft.com) with any additional questions or comments.

--- a/archive/pre-seo/docs/core_features.md
+++ b/archive/pre-seo/docs/core_features.md
@@ -1,0 +1,33 @@
+## 🛠️ Core Features
+![Pytorch-core-diagram](https://zenodo.org/records/15376499/files/Pytorch_Wildlife_core_figure.jpg)
+
+
+### 🌐 Unified Framework:
+Pytorch-Wildlife integrates **four pivotal elements:**
+
+▪ Machine Learning Models<br>
+▪ Pre-trained Weights<br>
+▪ Datasets<br>
+▪ Utilities<br>
+
+### 👷 Our work:
+In the provided graph, boxes outlined in red represent elements that will be added and remained fixed, while those in blue will be part of our development.
+
+
+### 🚀 Inaugural Model:
+We're kickstarting with YOLO as our first available model, complemented by pre-trained weights from `MegaDetector`. We have `MegaDetectorV5`, which is the same `MegaDetectorV5` model from the previous repository, and many different versions of `MegaDetectorV6` for different usecases.
+
+
+### 📚 Expandable Repository:
+As we move forward, our platform will welcome new models and pre-trained weights for camera traps and bioacoustic analysis. We're excited to host contributions from global researchers through a dedicated submission platform.
+
+
+### 🧰 Versatile Utilities:
+Our set of utilities spans from visualization tools to task-specific utilities, many inherited from Megadetector.
+
+
+### 💻 User Interface Flexibility:
+While we provide a foundational user interface, our platform is designed to inspire. We encourage researchers to craft and share their unique interfaces, and we'll list both existing and new UIs from other collaborators for the community's benefit.
+
+
+Let's shape the future of wildlife research, together! 🙌

--- a/archive/pre-seo/docs/index.md
+++ b/archive/pre-seo/docs/index.md
@@ -1,0 +1,63 @@
+![image](https://zenodo.org/records/15376499/files/Pytorch_Banner_transparentbk.png)
+
+<div align="center"> 
+<font size="6"> A Collaborative Deep Learning Framework for Conservation </font>
+<br>
+<hr>
+<a href="https://pypi.org/project/PytorchWildlife"><img src="https://img.shields.io/pypi/v/PytorchWildlife?color=limegreen" /></a> 
+<a href="https://pypi.org/project/PytorchWildlife"><img src="https://static.pepy.tech/badge/pytorchwildlife" /></a> 
+<a href="https://pypi.org/project/PytorchWildlife"><img src="https://img.shields.io/pypi/pyversions/PytorchWildlife" /></a> 
+<a href="https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Demo-blue" /></a>
+<a href="https://colab.research.google.com/drive/1rjqHrTMzEHkMualr4vB55dQWCsCKMNXi?usp=sharing"><img src="https://img.shields.io/badge/Colab-Demo-blue?logo=GoogleColab" /></a>
+<!-- <a href="https://colab.research.google.com/drive/16-OjFVQ6nopuP-gfqofYBBY00oIgbcr1?usp=sharing"><img src="https://img.shields.io/badge/Colab-Video detection-blue?logo=GoogleColab" /></a> -->
+<a href="https://github.com/microsoft/biodiversity/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/PytorchWildlife" /></a>
+<a href="https://discord.gg/TeEVxzaYtm"><img src="https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=Discord" /></a>
+<a href="https://microsoft.github.io/biodiversity/"><img src="https://img.shields.io/badge/Docs-526CFE?logo=MaterialForMkDocs&logoColor=white" /></a>
+<br><br>
+</div>
+
+
+## 👋 Welcome to Pytorch-Wildlife
+**PyTorch-Wildlife** is an AI platform designed for the AI for Conservation community to create, modify, and share powerful AI conservation models. It allows users to directly load a variety of models including [MegaDetector](https://microsoft.github.io/biodiversity/megadetector/), [DeepFaune](https://microsoft.github.io/biodiversity/megadetector/), and [HerdNet](https://github.com/Alexandre-Delplanque/HerdNet) from our ever expanding [model zoo](model_zoo/megadetector.md) for both animal detection and classification. In the future, we will also include models that can be used for applications, including underwater images and bioacoustics. We want to provide a unified and straightforward experience for both practicioners and developers in the AI for conservation field. Your engagement with our work is greatly appreciated, and we eagerly await any feedback you may have.
+
+
+## 🚀 Quick Start
+
+👇 Here is a brief example on how to perform detection and classification on a single image using `PyTorch-wildlife`
+```python
+import numpy as np
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+
+img = np.random.randn(3, 1280, 1280)
+
+# Detection
+detection_model = pw_detection.MegaDetectorV6() # Model weights are automatically downloaded.
+detection_result = detection_model.single_image_detection(img)
+
+#Classification
+classification_model = pw_classification.AI4GAmazonRainforest() # Model weights are automatically downloaded.
+classification_results = classification_model.single_image_classification(img)
+```
+
+## ⚙️ Install Pytorch-Wildlife
+```
+pip install PytorchWildlife
+```
+Please refer to our [installation guide](installation.md) for more installation information.
+
+
+## 🖼️ Examples
+
+### Image detection using `MegaDetector`
+<img src="https://zenodo.org/records/15376499/files/animal_det_1.JPG" alt="animal_det_1" width="300"/><br>
+*Credits to Universidad de los Andes, Colombia.*
+
+### Image classification with `MegaDetector` and `AI4GAmazonRainforest`
+<img src="https://zenodo.org/records/15376499/files/animal_clas_1.png" alt="animal_clas_1" width="300"/><br>
+*Credits to Universidad de los Andes, Colombia.*
+
+### Opossum ID with `MegaDetector` and `AI4GOpossum`
+<img src="https://zenodo.org/records/15376499/files/opossum_det.png" alt="opossum_det" width="300"/><br>
+*Credits to the Agency for Regulation and Control of Biosecurity and Quarantine for Galápagos (ABG), Ecuador.*
+

--- a/archive/pre-seo/docs/installation.md
+++ b/archive/pre-seo/docs/installation.md
@@ -1,0 +1,116 @@
+## Prerequisites
+1. Python 
+2. NVIDIA GPU for CUDA support (Optional, the code and demo also supports cpu calculation).
+3. `conda` or `mamba` for python environment management and specific version of `opencv`.
+4. If you are using CUDA. [CudaToolkit 12.1](https://developer.nvidia.com/cuda-12-1-0-download-archive) is required.
+4.1 If you are using CUDA and you have PytorchWildlife 1.0.2.14 or lower, [CudaToolkit 11.3](https://developer.nvidia.com/cuda-11.3.0-download-archive) is required.
+
+### Create environment
+If you have `conda` or `mamba` installed, you can create a new environment with the following commands (switch `conda` to `mamba` for `mamba` users):
+```bash
+conda create -n pytorch-wildlife python=3.10 -y
+conda activate pytorch-wildlife
+```
+NOTE: For Windows users, please use the Anaconda Prompt if you are using Anaconda. Otherwise, please use PowerShell for the conda environment and the rest of the set up.
+
+### Ubuntu
+If you are using a clean install of Ubuntu, additional libraries of OpenCV may need to be installed, please run the following command:
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-opencv
+```
+
+### MacOS
+If you are using MacOS, please run the following command to install ffmpeg for video decoding:
+```bash
+brew install ffmpeg
+```
+
+### Windows
+Windows installation is a bit more complicated due to operating system differences. Please refer to our [Windows installation guide](https://zenodo.org/records/15376499/files/PytorchWildlife_Windows_installation_tutorial.pdf) for details.
+
+### CUDA for Windows
+If you want to use your CUDA-compatible GPU and you are using Windows. Please run the following commands (CUDA 12.1 is required):
+
+```bash
+pip uninstall torch torchvision torchaudio
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+```
+
+## Installation
+
+### Install through pip:
+```bash
+pip install PytorchWildlife
+```
+## Using Docker
+
+1. Install Docker on your OS. Here are the guidelines for [Windows](https://docs.docker.com/desktop/install/windows-install/), [Ubuntu](https://docs.docker.com/engine/install/ubuntu/) and [Mac](https://docs.docker.com/desktop/install/mac-install/).
+2. Pull the docker image from our [DockerHub](https://hub.docker.com/repository/docker/andreshdz/pytorchwildlife/general).
+```bash
+docker pull andreshdz/pytorchwildlife:1.0.2.3
+```
+3. Run the gradio demo after pulling the image
+```bash
+docker run -p 80:80 andreshdz/pytorchwildlife:1.0.2.3 python demo/gradio_demo.py
+```
+4. If you want to run any code using the docker image,  please use `docker run andreshdz/pytorchwildlife:1.0.2.3` followed by the command that you want to execute.
+
+## Running the Demo
+Here is a brief example on how to perform detection and classification on a single image using `PyTorch-wildlife`:
+
+```python
+import numpy as np
+from PytorchWildlife.models import detection as pw_detection
+from PytorchWildlife.models import classification as pw_classification
+
+img = np.random.randn(3, 1280, 1280)
+
+# Detection
+detection_model = pw_detection.MegaDetectorV6() # Model weights are automatically downloaded.
+detection_result = detection_model.single_image_detection(img)
+
+#Classification
+classification_model = pw_classification.AI4GAmazonRainforest() # Model weights are automatically downloaded.
+classification_results = classification_model.single_image_classification(img)
+```
+
+If you want to use our Gradio demo for a user-friendly interface. Please run the following code inside the current repo. You can also find Jupyter Notebooks with an image and video tutorial:
+
+```bash
+git clone https://github.com/microsoft/biodiversity.git
+cd biodiversity
+cd demo
+# For the image demo
+python image_demo.py
+# For the video demo
+python video_demo.py
+# For the gradio app
+python gradio_demo.py
+```
+The `gradio_demo.py` will launch a Gradio interface where you can:
+- Perform Single Image Detection: Upload an image and set a confidence threshold to get detections.
+- Perform Batch Image Detection: Upload a zip file containing multiple images to get detections in a JSON format.
+- Perform Video Detection: Upload a video and get a processed video with detected animals. 
+
+As a showcase platform, the gradio demo offers a hands-on experience with all the available features. However, it's important to note that this interface is primarily for demonstration purposes. While it is fully equipped to run all the features effectively, it may not be optimized for scenarios involving excessive data loads. We advise users to be mindful of this limitation when experimenting with large datasets.
+
+Some browsers may not render processed videos due to unsupported codec. If that happens, please either use a newer version of browser or run the following for a `conda` version of `opencv` and choose `avc1` in the Video encoder drop down menu in the webapp (this might not work for MacOS):
+
+```bash
+pip uninstall opencv-python
+conda install -c conda-forge opencv
+```
+
+![image](https://zenodo.org/records/15376499/files/gradio_UI.png)
+
+**NOTE: Windows may encounter some errors with large file uploads making Batch Image Detection and Video Detection unable to process. It is a Gradio issue. Newer versions of Gradio in the future may fix this problem.**
+
+
+## Using Jupyter Notebooks
+[Juptyer](https://jupyter.org/) helps to progressively understand what each code block does. We have provided a set of demo files that can be read using Jupyter. If you have the Anaconda Navigator installed, you should have the option to run Jupyter. To make sure that the PytorchWildlife environment is recognized by Jupyter, please run the following code while your `pytorch-wildlife` environment is active:
+```bash
+conda install ipykernel
+python -m ipykernel install --user --name pytorch-wildlife --display-name "Python (PytorchWildlife)"
+```
+Once you execute the commands, you should be able to choose the `Python (PytorchWildlife)` kernel to start running the code!

--- a/archive/pre-seo/docs/license.md
+++ b/archive/pre-seo/docs/license.md
@@ -1,0 +1,16 @@
+# License
+
+## :bangbang: Model licensing 
+
+The **Pytorch-Wildlife** package is under MIT, however some of the models in the model zoo are not. For example, MegaDetectorV5, which is trained using the Ultralytics package, a package under AGPL-3.0, and is not for closed-source commercial uses if they are using updated 'ultralytics' packages. 
+
+There may be a confusion because YOLOv5 was initially released before the establishment of the AGPL-3.0 license. According to the official [Ultralytics-Yolov5](https://github.com/ultralytics/yolov5) package, it is under AGPL-3.0 now, and the maintainers have discussed how their licensing policy has evolved over time in their issues section. 
+
+We want to make Pytorch-Wildlife a platform where different models with different licenses can be hosted and want to enable different use cases. To reduce user confusions, in our [model zoo](#mag-model-zoo-and-release-schedules) section, we list all existing and planned future models in our model zoo, their corresponding license, and release schedules. 
+
+In addition, since the **Pytorch-Wildlife** package is under MIT, all the utility functions, including data pre-/post-processing functions and model fine-tuning functions in this packages are under MIT as well.
+
+
+```
+--8<-- "LICENSE.md"
+```

--- a/archive/pre-seo/docs/megadetector.md
+++ b/archive/pre-seo/docs/megadetector.md
@@ -1,0 +1,3 @@
+--8<-- "megadetector.md"
+
+ 

--- a/archive/pre-seo/docs/model_zoo/bioacoustics.md
+++ b/archive/pre-seo/docs/model_zoo/bioacoustics.md
@@ -1,0 +1,8 @@
+# Bioacoustics models
+
+|Models|Version Names|Licence|Release|Reference|
+|---|---|---|---|---|
+|MD_AudioBirds_V1|V1|MIT|Released|[PteroSet](https://github.com/microsoft/PteroSet)|
+
+>[!TIP]
+>`MD_AudioBirds_V1` is distributed as an ONNX file for direct inference. See the end-to-end walkthrough at [`PW_Bioacoustics/demo/bioacoustics_demo.ipynb`](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics/demo) for how to load the model, run inference, and visualise predictions.

--- a/archive/pre-seo/docs/model_zoo/classifiers.md
+++ b/archive/pre-seo/docs/model_zoo/classifiers.md
@@ -1,0 +1,13 @@
+# Classifiers
+
+|Models|Version Names|Licence|Release|
+|---|---|---|---|
+|AI4G-Oppossum|-|MIT|Released|
+|AI4G-Amazon-V1|v1|MIT|Released|
+|AI4G-Amazon-V2|v2|MIT|Released|
+|AI4G-Serengeti|-|MIT|Released|
+|Deepfaune-classification|v1.3|CC BY-SA 4.0|Released|[Deepfaune](https://www.deepfaune.cnrs.fr/en/)|
+|Deepfaune-New-England|v1.0|CC0 1.0 Universal|Released|[Deepfaune-New-England](https://code.usgs.gov/vtcfwru/deepfaune-new-england)|
+
+>[!TIP]
+>Some models, such as MegaDetectorV6, HerdNet, and AI4G-Amazon, have different versions, and they are loaded by their corresponding version names. Here is an example: `detection_model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")`.

--- a/archive/pre-seo/docs/model_zoo/megadetector.md
+++ b/archive/pre-seo/docs/model_zoo/megadetector.md
@@ -1,0 +1,40 @@
+# :mag: Model Zoo and Release Schedules
+
+|Models|Version Names|Licence|Release|Parameters (M)|mAR (Animal Class)|mAP50 (All Classes)|
+|---|---|---|---|---|---|---|
+|[MegaDetectorV5a](https://zenodo.org/records/15398270/files/md_v5a.0.0.pt?download=1)|a|AGPL-3.0|Released|139.9|81.7|92.0|
+|[MegaDetectorV5b](https://zenodo.org/records/15398270/files/MegaDetector_v5b.0.0.pt?download=1)|b|AGPL-3.0|Released|139.9|80.9|90.1|
+|[MegaDetectorV6-Ultralytics-YoloV9-Compact](https://zenodo.org/records/15398270/files/MDV6-yolov9-c.pt?download=1)|MDV6-yolov9-c|AGPL-3.0|Released|25.5|78.4|87.9|
+|[MegaDetectorV6-Ultralytics-YoloV9-Extra](https://zenodo.org/records/15398270/files/MDV6-yolov9-e-1280.pt?download=1)|MDV6-yolov9-e|AGPL-3.0|Released|58.1|82.1|88.6|
+|[MegaDetectorV6-Ultralytics-YoloV10-Compact](https://zenodo.org/records/15398270/files/MDV6-yolov10-c.pt?download=1) (even smaller and no NMS)|MDV6-yolov10-c|AGPL-3.0|Released|2.3|76.8|87.2|
+|[MegaDetectorV6-Ultralytics-YoloV10-Extra](https://zenodo.org/records/15398270/files/MDV6-yolov10-e-1280.pt?download=1) (extra large model and no NMS)|MDV6-yolov10-e|AGPL-3.0|Released|29.5|82.8|92.8|
+|[MegaDetectorV6-Ultralytics-RtDetr-Compact](https://zenodo.org/records/15398270/files/MDV6-rtdetr-c.pt?download=1)|MDV6-rtdetr-c|AGPL-3.0|Released|31.9|81.6|89.9|
+|MegaDetectorV6-Ultralytics-YoloV11-Compact|-|AGPL-3.0|Will Not Release|2.6|76.0|87.6|
+|MegaDetectorV6-Ultralytics-YoloV11-Extra|-|AGPL-3.0|Will Not Release|56.9|81.2|92.3|
+|[MegaDetectorV6-MIT-YoloV9-Compact](https://zenodo.org/records/15398270/files/MDV6-mit-yolov9-c.ckpt?download=1)|MDV6-mit-yolov9-c|MIT|Released|9.7|74.8|87.6|
+|[MegaDetectorV6-MIT-YoloV9-Extra](https://zenodo.org/records/15398270/files/MDV6-mit-yolov9-e.ckpt?download=1)|MDV6-mit-yolov9-e|MIT|Released|51|76.1|71.5|
+|[MegaDetectorV6-Apache-RTDetr-Compact](https://zenodo.org/records/15398270/files/MDV6-apa-rtdetr-c.pth?download=1)|MDV6-apa-rtdetr-c|Apache|Released|20|81.1|91.0|
+|[MegaDetectorV6-Apache-RTDetr-Extra](https://zenodo.org/records/15398270/files/MDV6-apa-rtdetr-e.pth?download=1)|MDV6-apa-rtdetr-e|Apache|Released|76|82.9|94.1|
+|MegaDetector-Overhead|-|MIT|Mid 2025|-|||
+|MegaDetector-Bioacoustics|-|MIT|Late 2025|-|||
+
+<!-- |Models|Version Names|Licence|Release|Parameters (M)|mAP<sup>val<br>50-95|Animal Recall|
+|---|---|---|---|---|---|---|
+|MegaDetectorV5|-|AGPL-3.0|Released|121|74.7|74.9|
+|MegaDetectorV6-Ultralytics-YoloV9-Compact|MDV6-yolov9-c|AGPL-3.0|Released|25.5|73.8|82.6|
+|MegaDetectorV6-Ultralytics-YoloV9-Extra|MDV6-yolov9-e|AGPL-3.0|Released|58.1|80.2|87.1|
+|MegaDetectorV6-Ultralytics-YoloV10-Compact (even smaller and no NMS)|MDV6-yolov10-c|AGPL-3.0|Released|2.3|71.8|78.8|
+|MegaDetectorV6-Ultralytics-YoloV10-Extra (extra large model and no NMS)|MDV6-yolov10-c|AGPL-3.0|Released|29.5|79.9|85.2|
+|MegaDetectorV6-Ultralytics-RtDetr-Compact|MDV6-redetr-c|AGPL-3.0|Released|31.9|73.9|83.4|
+|MegaDetectorV6-Ultralytics-YoloV11-Compact|-|AGPL-3.0|Will Not Release|2.6|71.9|79.8|
+|MegaDetectorV6-Ultralytics-YoloV11-Extra|-|AGPL-3.0|Will Not Release|56.9|79.3|86.0|
+|MegaDetectorV6-MIT-YoloV9-Compact|MDV6-mit-yolov9-c|MIT|MDV6-mit-yolov9-c|February 2025|9.7|73.84|-|
+|MegaDetectorV6-MIT-YoloV9-Extra|MDV6-mit-yolov9-c|MIT|February 2025|51|Training|Training|
+|MegaDetectorV6-Apache-RTDetr-Compact|MDV6-apa-redetr-c|Apache|February 2025|20|76.3|-|
+|MegaDetectorV6-Apache-RTDetr-Extra|MDV6-apa-redetr-c|Apache|February 2025|76|80.8|-| -->
+
+> [!TIP]
+> We are specifically reporting `Animal Recall` as our primary performance metric, even though it is not commonly used in traditional object detection studies, which typically focus on balancing overall model performance. For MegaDetector, our goal is to optimize for animal recall—in other words, minimizing false negative detections of animals or, more simply, ensuring our model misses as few animals as possible. While this may result in a higher false positive rate, we rely on downstream classification models to further filter the detected objects. We believe this approach is more practical for real-world animal monitoring scenarios.
+
+>[!TIP]
+>Some models, such as MegaDetectorV6, HerdNet, and AI4G-Amazon, have different versions, and they are loaded by their corresponding version names. Here is an example: `detection_model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")`.

--- a/archive/pre-seo/docs/model_zoo/other_detectors.md
+++ b/archive/pre-seo/docs/model_zoo/other_detectors.md
@@ -1,0 +1,12 @@
+# Other detection models 
+
+|Models|Version Names|Licence|Release|Reference|
+|---|---|---|---|---|
+|Deepfaune-detection|-|CC BY-SA 4.0|Released|[Deepfaune](https://www.deepfaune.cnrs.fr/en/)|
+|HerdNet-general|general|CC BY-NC-SA-4.0|Released|[Alexandre et. al. 2023](https://github.com/Alexandre-Delplanque/HerdNet)|
+|HerdNet-ennedi|ennedi|CC BY-NC-SA-4.0|Released|[Alexandre et. al. 2023](https://github.com/Alexandre-Delplanque/HerdNet)|
+|OWL-T (Overhead Wildlife Locator, Transformer)|T|MIT|Released|[OWL demo](https://github.com/microsoft/biodiversity/blob/main/demo/image_detection_demo_owl.ipynb)|
+|OWL-C (Overhead Wildlife Locator, CNN)|C|MIT|Released|[OWL demo](https://github.com/microsoft/biodiversity/blob/main/demo/image_detection_demo_owl.ipynb)|
+
+>[!TIP]
+>Some models, such as MegaDetectorV6, HerdNet, and AI4G-Amazon, have different versions, and they are loaded by their corresponding version names. Here is an example: `detection_model = pw_detection.MegaDetectorV6(version="MDV6-yolov10-e")`.

--- a/archive/pre-seo/docs/pw_engine_overview.md
+++ b/archive/pre-seo/docs/pw_engine_overview.md
@@ -1,0 +1,125 @@
+# PW-Engine Overview
+
+*A model-agnostic inference core for the PyTorch-Wildlife model zoo.*
+
+**Status:** Preview. Inference surfaces are feature-complete; a data-management layer is the next milestone.
+
+**In one sentence:** PW-Engine (full name: PyTorch-Wildlife Engine) is a Rust-based inference engine and HTTP service that runs the PyTorch-Wildlife model set, powers Sparrow Studio, and can be embedded as the backend of any inference-heavy application.
+
+---
+
+## Why
+
+PyTorch-Wildlife today runs PyTorch end-to-end. That is right for research — it keeps model code, training, and fine-tuning in one place — but it pays real deployment costs: multi-second cold starts, multi-GB Docker images, single-process concurrency limits, and no practical path to integrate with serious UI or desktop applications. Anything non-Python has to shell out to a Python process.
+
+To let UI developers — Sparrow Studio and anyone else — get both production-level latency and model-agnostic compatibility, we're building PW-Engine as a separate inference layer.
+
+| Prior deployment shape | Cause | PW-Engine response |
+|---|---|---|
+| Multi-second cold start | Python interpreter + server initialization | Sub-second cold start on GPU |
+| Multi-GB Docker images | Python + CUDA bloat | CPU image ~163 MB; GPU image ~4 GB |
+| GIL-bound concurrency | Single-process Python worker | Async HTTP server (axum/tokio); per-model serialization, multi-model concurrent |
+| Hard to embed in UI / desktop | PyTorch process is the only runtime; no FFI | Rust core with HTTP / CLI / Python / C-FFI surfaces — UI devs integrate natively |
+| Adding a model needs code changes | Hardcoded PyTorch model adapters | Drop an ONNX file + a manifest entry into the model directory |
+
+Because PyTorch-Wildlife today does not use ONNX at runtime, moving inference to PW-Engine (Rust + ONNX Runtime) is also a speed gain on top of the deployment-shape improvements above — not a wash against an ONNX baseline.
+
+---
+
+## What
+
+PW-Engine is a Rust core library with four consumption surfaces:
+
+```
+                    +---------------------------+
+                    |        PW-Engine          |
+                    |    (Rust core library)    |
+                    +---+--------+-------+------+
+                        |        |       |
+             +----------+        |       +----------+
+             |                   |                  |
+      +------+------+     +------+------+    +------+------+
+      |  HTTP       |     |   CLI       |    |  Python     |
+      |  server     |     |  (single    |    |  bindings   |
+      |  (REST,     |     |   binary,   |    |  (PyO3)     |
+      |  axum)      |     |   ~35 MB)   |    |             |
+      +------+------+     +------+------+    +------+------+
+             |                   |                  |
+             v                   v                  v
+        Docker /             Lab / CLI          Python apps
+        Sparrow Web          users              incl. PW SDK
+
+             +---- C FFI (generated header) ----+
+             v                                  v
+        Sparrow Studio                      Other native
+        Local (C#/P-Invoke)                 integrators
+```
+
+**Runtime:** ONNX Runtime (CPU or GPU). No PyTorch at inference time.
+
+**Model zoo:** PW-Engine targets full compatibility with the PyTorch-Wildlife model zoo. Adding a model is a manifest change plus an ONNX file in the model directory — no engine code change required.
+
+---
+
+## How to adopt
+
+Pick the surface that matches your stack.
+
+| You are a… | Surface you use | Notes |
+|---|---|---|
+| Conservation user | No direct use — you interact via Sparrow Studio | Install the MSI; PW-Engine runs underneath |
+| Existing Python user (`import PytorchWildlife`) | PyO3 bindings | Same API shape; drop-in |
+| Web/cloud deployer running an inference server | Docker HTTP container | `docker run`; call `/v1/detect` |
+| Laptop researcher | CLI — single static binary, ~35 MB | Invoke the CLI against a local image/audio file |
+| Desktop app developer (Windows/.NET first; Mac/Linux ports in progress) | C FFI / C# bindings | Same integration path Sparrow Studio Local uses |
+| Institutional / platform owner | Any combination | One inference implementation across desktop, server, and embedded |
+
+**Custom models:** drop an ONNX file plus a manifest entry into the model directory. No engine code change.
+
+**The Python PyTorch-Wildlife package keeps working.** PW-Engine is opt-in. Existing scripts and imports do not need to change; migrating to the PW-Engine Python bindings is a later, optional step.
+
+---
+
+## Status & roadmap
+
+| Layer | Status |
+|---|---|
+| Core library + ONNX Runtime integration | Complete |
+| HTTP REST server + Docker images | Complete |
+| CLI + Python bindings | Complete |
+| Utilities + model catalog | Complete |
+| Data-management layer (SQLite-backed annotations and queries) | Planned |
+| MLOps (model and data versioning) | Planned |
+| Multi-GPU scale-out | Not yet benchmarked |
+
+Reliability hardening for long-running GPU workloads is in progress.
+
+**Next milestone:** data-management sidecar.
+
+**Availability:** preview today via the Sparrow Studio beta.
+
+---
+
+## FAQ
+
+- **Does this replace PyTorch-Wildlife?**
+
+No. The Python PyTorch-Wildlife package remains the user-facing interface for training, fine-tuning, and research workflows. PW-Engine is the inference backend — over time, PyTorch-Wildlife itself will sit on top of PW-Engine rather than running PyTorch inference directly.
+
+- **When can I try it?**
+
+Through the Sparrow Studio beta (Windows MSI). We will update the beta in the next few weeks with PW-Engine as the core.
+
+- **Will my existing Python code break?**
+
+No. PW-Engine is opt-in; the current PyTorch-Wildlife API is unchanged.
+
+- **Why is it called "PyTorch-Wildlife Engine" if it doesn't use PyTorch at runtime?**
+
+We are thinking about a new name for the engine. Now we are keeping the PW branding.
+
+---
+
+## Pilot
+
+If you run an inference-heavy pipeline and want to pilot PW-Engine, reach out via the PyTorch-Wildlife Discord or email `zhongqimiao@microsoft.com`.

--- a/archive/pre-seo/docs/releases/past_releases.md
+++ b/archive/pre-seo/docs/releases/past_releases.md
@@ -1,0 +1,56 @@
+### Pytorch-Wildlife Version 1.2.4
+
+The inference code for the MIT YOLO and Apache RT‑DETR models is now available! To use either one, just load it like any other PyTorch‑Wildlife model:
+
+```python
+from pw_detection import MegaDetectorV6MIT, MegaDetectorV6Apache
+
+# MIT YOLO
+detector = MegaDetectorV6MIT(
+    device=DEVICE,
+    pretrained=True,
+    version="MDV6-mit-yolov9-e"
+)
+
+# Apache RT‑DETR
+detector = MegaDetectorV6Apache(
+    device=DEVICE,
+    pretrained=True,
+    version="MDV6-apa-rtdetr-e"
+)
+```
+Valid versions:
+- MDV6-mit-yolov9-c
+- MDV6-mit-yolov9-e
+- MDV6-apa-rtdetr-c
+- MDV6-apa-rtdetr-e
+
+You can also try out the full pipeline using the `detection_classification_pipeline_demo.py` script in the demo folder.
+
+### Pytorch-Wildlife Version 1.2.1
+
+#### SpeciesNet is available in Pytorch-Wildlife for testing! 
+- We have added SpeciesNet into our model zoo, which is compatible with all detection models provided by Pytorch-Wildlife. Please refer to [this document](https://github.com/microsoft/biodiversity/blob/SppNet_TF/PytorchWildlife/models/classification/speciesnet_base/sppnet_readme.md) for more details!
+
+#### Deepfaune in Our Model Zoo!! 
+- We are excited to announce the release of the Deepfaune models—both the detector and classifier—in PyTorch-Wildlife, adding to our growing model zoo. A huge thank you to the Deepfaune team for your support! Deepfaune is one of the most comprehensive models focused on the European ecosystem for both detection and classification. It serves as a great complement to MegaDetector, which has primarily been trained on datasets from North America, South America, and Africa. The Deepfaune detector is also our first third-party camera trap detection model integrated into PyTorch-Wildlife!
+- To use the model, you just need to load them as any other Pytorch-Wildife models: 
+```
+detection_model = pw_detection.DeepfauneDetector(device=DEVICE)
+classification_model = pw_classification.DeepfauneClassifier(device=DEVICE)
+```
+- You can also use the `detection_classification_pipeline_demo.py` script in the demo folder to test the whole detection + classification pipeline. 
+- Please also take a look at the original [Deepfaune website](https://www.deepfaune.cnrs.fr/en/) and give them a star! 
+
+#### Deepfaune-New-England in Our Model Zoo Too!!
+- Besides the original Deepfaune mode, there is another fine-tuned Deepfaune model developed by USGS for the Northeastern NA area called Deepfaune-New-England (DFNE). It can also be loaded with `classification_model = pw_classification.DFNE(device=DEVICE)`
+- Please take a look at the orignal [DFNE repo](https://code.usgs.gov/vtcfwru/deepfaune-new-england/-/tree/main?ref_type=heads) and give them a star! 
+
+### Pytorch-Wildlife Version 1.2.0
+- In this version of Pytorch-Wildlife, we are happy to release our [detection fine-tuning module](PW_FT_detection), with which users can fine-tune their own detection model from any released pre-trained MegaDetectorV6 models. Besides, this module also has functionalities that help users to prepare their datasets for the fine-tuning, just as our classification fine-tuning modules. For more details, please check the [readme](https://github.com/microsoft/biodiversity/blob/main/PW_FT_detection). Currently the fine-tuning is based on [Ultralytics](https://www.ultralytics.com/) with AGPL. We will release MIT versions in the future. Here is the [release page](https://github.com/microsoft/biodiversity/releases).
+- We have also released additional MegaDetectorV6 models based on Yolo-v10 and RtDetr. We have skipped Yolo-v11 models because of limited performance and architectural gains. Most of the MIT and Apache versions have also finished training but are waiting for internal review before they can be released.
+- We have also updated our AI4G-Amazon model with bigger datasets and it has a better performance compared to previous iterations. Please feel free to test it or fine-tune on it. 
+- We will also make a new roadmap for 2025 in the next couple of updates.
+- Special thanks to [José Díaz](https://github.com/jdiaz97) for his great cross-platform app, [BoquilaHUB](https://github.com/boquila/boquilahub), that is even working on ios and android! Please check his repo out! In the future, we will create a project gallery showcasing projects that use or are build upon Pytorch-Wildlife. If you want your projects to be included, please feel free to reach out to us on [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PytorchWildife)](https://discord.gg/TeEVxzaYtm)
+
+<img src="https://github.com/boquila/boquilahub/blob/main/readme.jpg?raw=true" alt="animal_det_1" width="300"/><br>

--- a/archive/pre-seo/docs/releases/release_notes.md
+++ b/archive/pre-seo/docs/releases/release_notes.md
@@ -1,0 +1,21 @@
+# Main changes and additions
+
+### V 1.3.0
+
+This release has three parts plus a preview of what's next.
+
+#### Sparrow Studio beta
+
+Sparrow Studio is our new graphical frontend — data management, inference, analysis, and annotation in one UI. The Windows MSI installer is available from Zenodo: [SPARROW Studio Installer](https://zenodo.org/records/19687738/files/SPARROW%20Studio%20Installer.msi?download=1) (signed). Mac and Linux builds are in progress.
+
+#### Bioacoustics module
+
+A dedicated bioacoustics module at [`PW_Bioacoustics/`](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics) with CLI scripts for dataset preparation, training, and inference on audio recordings, plus a pre-trained bird classifier (`MD_AudioBirds_V1`). See the [bioacoustics overview](../bioacoustics.md), the [model-zoo entry](../model_zoo/bioacoustics.md), and the end-to-end demo at [`PW_Bioacoustics/demo/bioacoustics_demo.ipynb`](https://github.com/microsoft/biodiversity/tree/main/PW_Bioacoustics/demo).
+
+#### OWL (Overhead Wildlife Locator)
+
+A new generalized, point-based detection model for overhead imagery. Two variants are released — OWL-T and OWL-C — listed in the [Other Detectors](../model_zoo/other_detectors.md) model zoo. Demo: [`demo/image_detection_demo_owl.ipynb`](https://github.com/microsoft/biodiversity/blob/main/demo/image_detection_demo_owl.ipynb).
+
+#### Looking ahead — PW-Engine
+
+The future of PyTorchWildlife is [**PW-Engine**](../pw_engine_overview.md), a Rust-based, model-agnostic inference core that powers Sparrow Studio and can also be consumed directly via HTTP, CLI, Python bindings, or a native C library. See the PW-Engine overview for what it is, how it fits alongside the current Python API, and how to pilot it.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,5 @@
+---
+description: "Browse all topics across the PyTorch-Wildlife and MegaDetector documentation."
+---
+
+# Tags

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,12 +70,13 @@ theme:
     - navigation.footer
 
 nav:
-  - Pytorch Wildlife:
+  - PyTorch-Wildlife:
     - Overview: index.md
     - Core Features: core_features.md
     - MegaDetector: megadetector.md
     - MegaDetector-Acoustics: bioacoustics.md
     - Installation: installation.md
+    - Tags: tags.md
     - Existing Collaborators: collaborators.md
     - Contributors: contributors.md
     - Cite Us: cite.md
@@ -180,6 +181,8 @@ markdown_extensions:
 plugins:
   - search
   - meta
+  - tags:
+      tags_file: tags.md
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
## Summary
- Corrects nav label `Pytorch Wildlife` → `PyTorch-Wildlife` to match approved naming conventions and SEO keyword consistency
- Enables the Material for MkDocs `tags` plugin with `tags_file: tags.md` so tag chips on each page link to a browsable `/tags/` index
- Adds `docs/tags.md` as the tags index page (Material auto-populates it from front matter tags across all pages)

## Test plan
- [ ] Run `mkdocs serve` and navigate to `/tags/` — should list all tags with links to associated pages
- [ ] Click a tag (e.g., "MegaDetector") — should show all pages tagged with it
- [ ] Confirm tag chips appear on individual pages and link back to the index
- [ ] Confirm "Tags" appears in the nav under PyTorch-Wildlife

🤖 Generated with [Claude Code](https://claude.com/claude-code)