### PR TITLE
fix: update stale CameraTraps URLs in megadetector.md snippet

### DIFF
--- a/megadetector.md
+++ b/megadetector.md
@@ -21,7 +21,7 @@ We will also continuously fine-tune our V6 models on newly collected public and 
 > [!TIP]
 > All versions of MegaDetector and corresponding performance can be found in the [model zoo](https://microsoft.github.io/Biodiversity/model_zoo/megadetector/).
 
-> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model that fits the project needs. To reduce potential confusion, we have also standardized the model names into MDV6-Compact and MDV6-Extra for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/CameraTraps/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/Biodiversity/demo_and_ui/demo_data/).
+> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model that fits the project needs. To reduce potential confusion, we have also standardized the model names into MDV6-Compact and MDV6-Extra for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/Biodiversity/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/Biodiversity/demo_and_ui/demo_data/).
 
 <!-- In the following figure, we can see the Performance to Parameter metric of each released MegaDetector model. All of the V6 models, extra large or compact, have at least 50% less parameters compared to MegaDetectorV5 but with much higher animal detection performance. -->
 
@@ -32,7 +32,7 @@ We will also continuously fine-tune our V6 models on newly collected public and 
 
 ## MegaDetectorV5 and Archive Repos
 
-For those interested in accessing the previous MegaDetector repository, which utilizes the same `MegaDetectorV5` model weights and was primarily developed by Dan Morris during his time at Microsoft, please visit the [archive branch](https://github.com/microsoft/CameraTraps/tree/archive) , or you can visit this [forked repository](https://github.com/agentmorris/MegaDetector/tree/main) that Dan Morris is currently actively maintaining.
+For those interested in accessing the previous MegaDetector repository, which utilizes the same `MegaDetectorV5` model weights and was primarily developed by Dan Morris during his time at Microsoft, please visit the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`), or you can visit this [forked repository](https://github.com/agentmorris/MegaDetector/tree/main) that Dan Morris is currently actively maintaining.
 
 >[!TIP]
 >If you have any questions regarding MegaDetector and Pytorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PytorchWildife)](https://discord.gg/TeEVxzaYtm)


### PR DESCRIPTION
## Summary

- Fixes two stale `microsoft/CameraTraps` URLs in the root-level `megadetector.md` snippet source that were missed by PR #636 (which only scanned `docs/`)
- Updates image demo link to point to `microsoft/Biodiversity`
- Updates archive branch link to point to `microsoft/Biodiversity/tree/archive` with a `(formerly \`microsoft/CameraTraps\`)` note, matching the phrasing already used in the Megadetector repo docs

## Test plan

- [ ] Verify https://microsoft.github.io/Biodiversity/megadetector/#megadetectorv5-and-archive-repos no longer shows CameraTraps links after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)