### PR TITLE
fix: ignore PW_FT_detection dir and update LICENSE snippet ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ PytorchWildlife.egg-info/
 *.pth
 *.cache
 *.pem
+PW_FT_detection/
 PW_FT_detection/runs/
 demo/runs/
 site/

--- a/docs/license.md
+++ b/docs/license.md
@@ -21,5 +21,5 @@ In addition, since the **PyTorch-Wildlife** package is under MIT, all the utilit
 
 
 ```
---8<-- "LICENSE.md"
+--8<-- "LICENSE"
 ```


### PR DESCRIPTION
## Summary
- Add `PW_FT_detection/` to `.gitignore` so it is not tracked as a submodule by the parent repo
- Fix `docs/license.md` snippet include reference from `LICENSE.md` → `LICENSE`, following the file rename in #638

## Test plan
- [ ] Verify `PW_FT_detection/` no longer appears in `git status` for this repo
- [ ] Verify the License page renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)