### PR TITLE
docs: add SEO front matter to remaining hand-written pages

### DIFF
--- a/docs/build_mkdocs.md
+++ b/docs/build_mkdocs.md
@@ -1,3 +1,12 @@
+---
+description: "How to build and deploy the PyTorch-Wildlife MkDocs documentation site locally and to GitHub Pages."
+tags:
+  - PyTorch-Wildlife
+  - documentation
+  - MkDocs
+  - developer guide
+---
+
 # Building the MkDocs Site
 
 To build the MkDocs site locally, follow these steps:

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,1 +1,9 @@
+---
+description: "PyTorch-Wildlife contributors — the researchers and engineers behind the Microsoft AI for Good Lab biodiversity tools."
+tags:
+  - PyTorch-Wildlife
+  - contributors
+  - Microsoft AI for Good
+---
+
 # In construction

--- a/docs/demo_and_ui/demo_data.md
+++ b/docs/demo_and_ui/demo_data.md
@@ -1,2 +1,11 @@
+---
+description: "Download demo data for PyTorch-Wildlife notebooks and Gradio web app. Camera-trap sample images for testing MegaDetector and species classifiers."
+tags:
+  - PyTorch-Wildlife demo
+  - demo data
+  - camera trap images
+  - MegaDetector
+---
+
 # Prepare data for demos
 Before we run any demos, please download some demo data for our demo notebooks and webapps from this [link](https://zenodo.org/records/15376499/files/demo_data_base.zip?download=1) and decompress the data in the [demo folder](https://github.com/microsoft/Biodiversity/tree/main/demo). 

--- a/docs/demo_and_ui/ecoassist.md
+++ b/docs/demo_and_ui/ecoassist.md
@@ -1,2 +1,12 @@
+---
+description: "PyTorch-Wildlife models available in AddaxAI (formerly EcoAssist) — load MegaDetector and classifiers for wildlife image analysis on your local computer."
+tags:
+  - AddaxAI
+  - EcoAssist
+  - PyTorch-Wildlife
+  - MegaDetector
+  - wildlife UI
+---
+
 # PyTorch-Wildlife models are available with AddaxAI (formerly EcoAssist)!
 We are thrilled to announce our collaboration with [AddaxAI](https://addaxdatascience.com/addaxai/#spp-models)---a powerful user interface software that enables users to directly load models from the PyTorch-Wildlife model zoo for image analysis on local computers. With AddaxAI, you can now utilize MegaDetectorV5 and the classification models---AI4GAmazonRainforest and AI4GOpossum---for automatic animal detection and identification, alongside a comprehensive suite of pre- and post-processing tools. This partnership aims to enhance the overall user experience with PyTorch-Wildlife models for a general audience. We will work closely to bring more features together for more efficient and effective wildlife analysis in the future. Please refer to their tutorials on how to use PyTorch-Wildlife models with AddaxAI. 

--- a/docs/demo_and_ui/gradio.md
+++ b/docs/demo_and_ui/gradio.md
@@ -1,3 +1,11 @@
+---
+description: "Explore PyTorch-Wildlife and MegaDetector through the Gradio web interface — single image detection, batch processing, and video analysis."
+tags:
+  - PyTorch-Wildlife demo
+  - Gradio
+  - MegaDetector
+  - wildlife detection UI
+---
 
 ## 🕵️ Explore PyTorch-Wildlife and MegaDetector with our Demo User Interface
 

--- a/docs/demo_and_ui/notebook.md
+++ b/docs/demo_and_ui/notebook.md
@@ -1,3 +1,12 @@
+---
+description: "PyTorch-Wildlife demo scripts and Jupyter notebooks for image detection, video processing, and classification with MegaDetector."
+tags:
+  - PyTorch-Wildlife demo
+  - Jupyter notebooks
+  - MegaDetector demo
+  - camera trap demo
+---
+
 # Demo Scripts and Notebooks
 
 ### Local notebooks

--- a/docs/demo_and_ui/timelapse.md
+++ b/docs/demo_and_ui/timelapse.md
@@ -1,2 +1,11 @@
+---
+description: "PyTorch-Wildlife integration with TimeLapse — native output formats compatible with TimeLapse for camera-trap image review workflows."
+tags:
+  - PyTorch-Wildlife
+  - TimeLapse
+  - camera trap workflow
+  - MegaDetector
+---
+
 # PyTorch-Wildlife and TimeLapse
 PyTorch-Wildlife offers native output formats that are directly compatible with TimeLapse. We will provide more details on this in future releases! We will keep you posted! 

--- a/docs/fine_tuning_modules/classification/overview.md
+++ b/docs/fine_tuning_modules/classification/overview.md
@@ -1,1 +1,10 @@
+---
+description: "PyTorch-Wildlife classification fine-tuning — adapt species classifiers to your own datasets and geographic regions."
+tags:
+  - PyTorch-Wildlife
+  - classification fine-tuning
+  - species classification
+  - transfer learning
+---
+
 # In Construction

--- a/docs/fine_tuning_modules/detection/overview.md
+++ b/docs/fine_tuning_modules/detection/overview.md
@@ -1,2 +1,10 @@
+---
+description: "PyTorch-Wildlife detection fine-tuning — fine-tune MegaDetector on your own camera-trap data for improved local performance."
+tags:
+  - PyTorch-Wildlife
+  - detection fine-tuning
+  - MegaDetector
+  - transfer learning
+---
 
 # In Construction

--- a/docs/fine_tuning_modules/overview.md
+++ b/docs/fine_tuning_modules/overview.md
@@ -1,1 +1,10 @@
+---
+description: "PyTorch-Wildlife fine-tuning modules — adapt MegaDetector and classification models to your own camera-trap datasets."
+tags:
+  - PyTorch-Wildlife
+  - fine-tuning
+  - MegaDetector
+  - transfer learning
+---
+
 # In construction


### PR DESCRIPTION
## Summary

Adds `description:` and `tags:` front matter to 10 hand-written docs pages that were missing it. All other docs pages already have front matter.

**Pages updated:**
- `docs/build_mkdocs.md`
- `docs/contributors.md`
- `docs/demo_and_ui/demo_data.md`
- `docs/demo_and_ui/ecoassist.md`
- `docs/demo_and_ui/gradio.md`
- `docs/demo_and_ui/notebook.md`
- `docs/demo_and_ui/timelapse.md`
- `docs/fine_tuning_modules/overview.md`
- `docs/fine_tuning_modules/classification/overview.md`
- `docs/fine_tuning_modules/detection/overview.md`

**Not in scope:** `docs/base/` API reference stubs (29 files) — tracked as a separate follow-up.

## Test plan
- [ ] `find docs -name "*.md" | grep -v "^docs/base/" | xargs grep -L "^description:"` returns empty
- [ ] `mkdocs build` passes