### PR TITLE
Replace WildlifeClassification with MegaDetector-Classifier, remove Bongo from Projects table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ So we made a deliberate decision: break the work into focused, dedicated reposit
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Overhead imagery detection — point-based wildlife localization from aerial views |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection — processing and feature detection in sidescan sonar imagery |
 | [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework and model zoo for conservation AI |
-| [microsoft/WildlifeClassification](https://github.com/microsoft/WildlifeClassification) | Species classification models, running downstream of MegaDetector detection |
-| [microsoft/Bongo](https://github.com/microsoft/Bongo) | *(Owner-populated)* |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI edge device for remote field deployments |
 | [microsoft/SPARROW-Studio](https://github.com/microsoft/SPARROW-Studio) | The all-in-one desktop UI for running every model in this ecosystem |
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ So we made a deliberate decision: break the work into focused, dedicated reposit
 |---|---|
 | [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | AI model for detecting animals, people, and vehicles in camera-trap imagery — where it all started |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic AI for biodiversity monitoring — audio classification and species identification from sound |
+| [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Overhead imagery detection — point-based wildlife localization from aerial views |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection — processing and feature detection in sidescan sonar imagery |
 | [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework and model zoo for conservation AI |


### PR DESCRIPTION
## Summary

- Adds \`microsoft/MegaDetector-Classifier\` to the ecosystem Projects table — the new standalone repo for camera-trap species classification fine-tuning, spun off from \`Biodiversity/PW_FT_classification\`
- Removes \`microsoft/WildlifeClassification\` (superseded by MegaDetector-Classifier)
- Removes \`microsoft/Bongo\` (no public content yet)

## Test plan

- [ ] Table renders correctly in GitHub markdown preview — MegaDetector-Classifier present, WildlifeClassification and Bongo absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)