### PR TITLE
Remove SPARROW-Studio cross-links; update ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Microsoft AI for Good Lab — camera-trap detection, bioacoustic analysis, speci
 
 Our journey started with **MegaDetector** — a camera-trap animal detection model that became a widely adopted tool in the conservation community. Building on that foundation, we created **PyTorch-Wildlife** as a unified platform to host all of our AI for biodiversity work, bringing together detection, classification, and eventually much more.
 
-Over time, our scope grew well beyond camera-trap imagery. We now have active work in bioacoustics, overhead animal detection, edge computing for remote field deployments, and a dedicated desktop UI — **SPARROW Studio** — that runs every model we produce. As the ecosystem expanded, it became clear that keeping everything inside a single repository was working against us. Code was harder to find, harder to maintain, and harder to extend.
+Over time, our scope grew well beyond camera-trap imagery. We now have active work in bioacoustics, overhead animal detection, and edge computing for remote field deployments. As the ecosystem expanded, it became clear that keeping everything inside a single repository was working against us. Code was harder to find, harder to maintain, and harder to extend.
 
 So we made a deliberate decision: break the work into focused, dedicated repositories — one per project — where the code in each repo is concentrated, the ownership is clear, and future contributors know exactly where to go. This repository is the hub that ties them together. PyTorch-Wildlife now lives at [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife), MegaDetector at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector), and everything else is linked in the table below.
 
@@ -42,7 +42,6 @@ So we made a deliberate decision: break the work into focused, dedicated reposit
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection — processing and feature detection in sidescan sonar imagery |
 | [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework and model zoo for conservation AI |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI edge device for remote field deployments |
-| [microsoft/SPARROW-Studio](https://github.com/microsoft/SPARROW-Studio) | The all-in-one desktop UI for running every model in this ecosystem |
 
 ## Cite us
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ tags:
 ## 👋 Welcome to PyTorch-Wildlife
 **PyTorch-Wildlife** is an AI platform designed for the AI for Conservation community to create, modify, and share powerful AI conservation models. It allows users to directly load a variety of models including [MegaDetector](https://microsoft.github.io/Biodiversity/megadetector/), [DeepFaune](https://microsoft.github.io/Biodiversity/megadetector/), and [HerdNet](https://github.com/Alexandre-Delplanque/HerdNet) from our ever expanding [model zoo](model_zoo/megadetector.md) for both animal detection and classification.
 
-Our scope now spans well beyond camera-trap imagery — we have active work in [MegaDetector-Acoustic](bioacoustics.md) for bioacoustic species identification, [MegaDetector-Overhead](model_zoo/other_detectors.md) for aerial wildlife detection, edge computing for remote field deployments, and [SPARROW Studio](releases/release_notes.md) — a dedicated desktop UI that runs every model we produce.
+Our scope now spans well beyond camera-trap imagery — we have active work in [MegaDetector-Acoustic](bioacoustics.md) for bioacoustic species identification, [MegaDetector-Overhead](model_zoo/other_detectors.md) for aerial wildlife detection, and edge computing for remote field deployments.
 
 > **Coming from an older version?** OWL is now **MegaDetector-Overhead**, the bioacoustics module is now **MegaDetector-Acoustic**, and the repo has moved from `microsoft/CameraTraps` to `microsoft/Biodiversity` (old links redirect automatically). See the [full naming changes](releases/release_notes.md#naming-changes) in the v1.3.0 release notes.
 


### PR DESCRIPTION
## Summary

- Remove SPARROW-Studio table row and narrative references from `README.md` and `docs/index.md` — the repo is not launching yet
- Add MegaDetector-Classifier to ecosystem projects table
- Remove WildlifeClassification and Bongo placeholder rows

## Test plan

- [ ] Verify no broken links remain in README or docs/index pointing to SPARROW-Studio
- [ ] Confirm ecosystem table renders correctly on GitHub and Pages