### PR TITLE
chore: rewrite megadetector.md as permanent transition page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ tags:
 
 
 ## 👋 Welcome to PyTorch-Wildlife
-**PyTorch-Wildlife** is an AI platform designed for the AI for Conservation community to create, modify, and share powerful AI conservation models. It allows users to directly load a variety of models including [MegaDetector](https://microsoft.github.io/Biodiversity/megadetector/), [DeepFaune](https://microsoft.github.io/Biodiversity/megadetector/), and [HerdNet](https://github.com/Alexandre-Delplanque/HerdNet) from our ever expanding [model zoo](model_zoo/megadetector.md) for both animal detection and classification.
+**PyTorch-Wildlife** is an AI platform designed for the AI for Conservation community to create, modify, and share powerful AI conservation models. It allows users to directly load a variety of models including [MegaDetector](https://github.com/microsoft/MegaDetector), [DeepFaune](https://www.deepfaune.cnrs.fr/en/), and [HerdNet](https://github.com/Alexandre-Delplanque/HerdNet) from our ever expanding [model zoo](model_zoo/megadetector.md) for both animal detection and classification.
 
 Our scope now spans well beyond camera-trap imagery — we have active work in [MegaDetector-Acoustic](bioacoustics.md) for bioacoustic species identification, [MegaDetector-Overhead](model_zoo/other_detectors.md) for aerial wildlife detection, and edge computing for remote field deployments.
 

--- a/megadetector.md
+++ b/megadetector.md
@@ -1,38 +1,39 @@
-# 🐾 Pytorch-Wildlife and MegaDetector
+# MegaDetector
 
-> [!TIP]
-> MegaDetector now resides in [Pytorch-Wildlife](https://microsoft.github.io/Biodiversity/megadetector/) as part of the [model zoo](https://microsoft.github.io/Biodiversity/model_zoo/megadetector/).
+> **MegaDetector** is Microsoft's open-source AI model for camera-trap conservation — it detects animals, people, and vehicles in camera-trap imagery and filters out blank images, reducing manual review across large datasets. Developed and maintained by the **Microsoft AI for Good Lab**.
 
-**At the core of our mission is the desire to create a harmonious space where conservation scientists from all over the globe can unite. Where they're able to share, grow, use datasets and deep learning architectures for wildlife conservation.
-We've been inspired by the potential and capabilities of Megadetector, and we deeply value its contributions to the community. As we forge ahead with Pytorch-Wildlife, under which Megadetector now resides, please know that we remain committed to supporting, maintaining, and developing Megadetector, ensuring its continued relevance, expansion, and utility.**
+> [!IMPORTANT]
+> **This page has moved. MegaDetector's canonical home is now [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector).**
+> Source code, releases, issues, the model zoo, the full version history (V1–V6), benchmarks, and the list of organizations using MegaDetector all live there. This page remains only as a pointer to the canonical repository.
 
+## Where things live
 
-## :racing_car::dash::dash: MegaDetectorV6: SMALLER, FASTER, BETTER!  
-We have officially released our 6th version of MegaDetector, MegaDetectorV6! In the next generation of MegaDetector, we are focusing on computational efficiency, performance, modernizing of model architectures, and licensing. We have trained multiple new models using different model architectures that are optimized for performance and low-budget devices, including Yolo-v9, Yolo-v10, and RT-Detr for maximum user flexibility. For example, the MegaDetectorV6-Ultralytics-YoloV10-Compact (MDV6-yolov10-c) model only have ***2% of the parameters*** of the previous MegaDetectorV5 and still exhibits comparable performance on our validation datasets. 
+| You want… | Go to |
+|---|---|
+| MegaDetector source, releases, issues, V1–V6 history, benchmarks | **[microsoft/MegaDetector](https://github.com/microsoft/MegaDetector)** |
+| The PyTorch-Wildlife framework that hosts MegaDetector and classifiers | [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) |
+| The biodiversity ecosystem umbrella (all repos, one hub) | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) |
+| The AI-enabled edge device that runs MegaDetector in the field | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) |
 
-To test the newest version of MegaDetector with all the existing functionalities, you can use our [Hugging Face interface](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife) or simply load the model with **Pytorch-Wildlife**. The weights will be automatically downloaded: 
+## Run MegaDetectorV6 quickly
+
+The current generation is **MegaDetectorV6** (smaller, faster architectures including YOLOv9, YOLOv10, and RT-DETR; the compact variant is roughly 2% of the V5 parameter count at comparable accuracy). Try it without writing code via the [Hugging Face Space](https://huggingface.co/spaces/ai-for-good-lab/pytorch-wildlife), or load it through PyTorch-Wildlife:
+
 ```python
 from PytorchWildlife.models import detection as pw_detection
 detection_model = pw_detection.MegaDetectorV6()
 ```
 
-We will also continuously fine-tune our V6 models on newly collected public and private data to further improve the generalization performance.
+Full usage, model selection, and the fine-tuning pipeline are documented in **[microsoft/MegaDetector](https://github.com/microsoft/MegaDetector)**.
 
-> [!TIP]
-> All versions of MegaDetector and corresponding performance can be found in the [model zoo](https://microsoft.github.io/Biodiversity/model_zoo/megadetector/).
+## MegaDetectorV5 and earlier
 
-> From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model that fits the project needs. To reduce potential confusion, we have also standardized the model names into MDV6-Compact and MDV6-Extra for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](https://github.com/microsoft/Biodiversity/blob/main/demo/image_demo.py) and our [demo data installation guideline](https://microsoft.github.io/Biodiversity/demo_and_ui/demo_data/).
+For `MegaDetectorV5` weights and the original repository — primarily developed by Dan Morris during his time at Microsoft — see the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of this repository (formerly `microsoft/CameraTraps`). Dan continues to actively maintain a community fork at [agentmorris/MegaDetector](https://github.com/agentmorris/MegaDetector), which remains a valuable resource for the community.
 
-<!-- In the following figure, we can see the Performance to Parameter metric of each released MegaDetector model. All of the V6 models, extra large or compact, have at least 50% less parameters compared to MegaDetectorV5 but with much higher animal detection performance. -->
+## Citing MegaDetector
 
-<!-- ![image](assets/ParamPerf.png) -->
+A `citation.cff` is maintained on [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) for automated citation tools. Cite **Beery, Morris, Yang 2019 — *Efficient Pipeline for Camera Trap Image Review*** for MegaDetector specifically, and **Hernandez et al. 2024 — *Pytorch-Wildlife*** for the framework.
 
-<!-- >[!TIP] -->
-<!-- >From now on, we encourage our users to use MegaDetectorV6 as their default animal detection model and choose whichever model that fits the project needs. To reduce potential confusion, we have also standardized the model names into MDV6-Compact and MDV6-Extra for two model sizes using the same architecture. Learn how to use MegaDetectorV6 in our [image demo](demo/image_detection_demo_v6.ipynb) and [video demo](demo/video_detection_demo_v6.ipynb). -->
+## Contact
 
-## MegaDetectorV5 and Archive Repos
-
-For those interested in accessing the previous MegaDetector repository, which utilizes the same `MegaDetectorV5` model weights and was primarily developed by Dan Morris during his time at Microsoft, please visit the [archive branch](https://github.com/microsoft/Biodiversity/tree/archive) of the Biodiversity repository (formerly `microsoft/CameraTraps`), or you can visit this [forked repository](https://github.com/agentmorris/MegaDetector/tree/main) that Dan Morris is currently actively maintaining.
-
->[!TIP]
->If you have any questions regarding MegaDetector and Pytorch-Wildlife, please [email us](mailto:zhongqimiao@microsoft.com) or join us in our discord channel: [![](https://img.shields.io/badge/any_text-Join_us!-blue?logo=discord&label=PytorchWildife)](https://discord.gg/TeEVxzaYtm)
+Questions about MegaDetector or PyTorch-Wildlife: open an issue on [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector/issues) or join the [Discord](https://discord.gg/TeEVxzaYtm).


### PR DESCRIPTION
## Summary

Rewrites `megadetector.md` in `microsoft/Biodiversity` as a thin, permanent transition page that declares `microsoft/MegaDetector` as the canonical home and cross-links forward. Keeps the URL live — no 404s, no broken inbound links, no reindex latency. Also corrects two stale/wrong links in the homepage.

## Files changed

| File | Change |
|---|---|
| `megadetector.md` | Full rewrite to transition page. Replaces stale "MegaDetector now resides in Pytorch-Wildlife" framing with a canonical pointer, a cross-link table, a quick-start code block, V5/archive notes, citation, and contact. Content is verbatim per brief. |
| `docs/index.md` | Line 31: `[MegaDetector]` repointed from the Biodiversity Pages route to `github.com/microsoft/MegaDetector`. `[DeepFaune]` corrected from the wrong megadetector route to the official `deepfaune.cnrs.fr/en/` site (consistent with all other DeepFaune refs in the repo). |

## What was NOT changed

- `docs/megadetector.md` — the MkDocs snippet wrapper (`--8<-- "megadetector.md"`) picks up the new content automatically; no edit needed.
- `docs/model_zoo/megadetector.md` — separate model-specs page, different route, out of scope.
- Archive branch refs, `agentmorris/MegaDetector`, `microsoft/PytorchWildlife` — all correct as-is, untouched.
- No redirects, canonical tags, meta-refresh, or HTML artifacts added anywhere.

## Verification

`mkdocs build` completed cleanly (3.44s, no new warnings). The `/megadetector/` route still renders via the snippet include, now showing the transition content.

## Related

ADO Epics 506340 (Phase 1 — Repo Optimization) and 513541 (Phase 2 — Web Properties Integration).