### PR TITLE
Fix broken and legacy repo URLs

### DIFF
--- a/PW_FT_classification/README.md
+++ b/PW_FT_classification/README.md
@@ -1,6 +1,6 @@
 # Classification fine-tuning
 
-This repository focuses on training classification models for Pytorch-Wildlife. This module is designed to help both programmers and biologists train a classification model for animal identification. The output weights of this training codebase can be easily integrated in our [Pytorch-Wildlife](https://github.com/microsoft/CameraTraps/) framework. Our goal is to make this tool accessible and easy to use, regardless of your background in machine learning or programming.
+This repository focuses on training classification models for Pytorch-Wildlife. This module is designed to help both programmers and biologists train a classification model for animal identification. The output weights of this training codebase can be easily integrated in our [Pytorch-Wildlife](https://github.com/microsoft/Biodiversity/) framework. Our goal is to make this tool accessible and easy to use, regardless of your background in machine learning or programming.
 
 ## Installation
 
@@ -120,7 +120,7 @@ This command will initiate the training process based on the parameters specifie
 
 ## Output
 
-Once training is complete, the output weights will be saved in the `weights` directory. These weights can be used to classify new images using the [Pytorch-Wildlife](https://github.com/microsoft/CameraTraps/)
+Once training is complete, the output weights will be saved in the `weights` directory. These weights can be used to classify new images using the [Pytorch-Wildlife](https://github.com/microsoft/Biodiversity/)
 
 We are working on adding a feature in a future release to directly integrate the output weights with the Pytorch-Wildlife framework and the Gradio App.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Our journey started with **MegaDetector** — a camera-trap animal detection mod
 
 Over time, our scope grew well beyond camera-trap imagery. We now have active work in bioacoustics, overhead animal detection, and edge computing for remote field deployments. As the ecosystem expanded, it became clear that keeping everything inside a single repository was working against us. Code was harder to find, harder to maintain, and harder to extend.
 
-So we made a deliberate decision: break the work into focused, dedicated repositories — one per project — where the code in each repo is concentrated, the ownership is clear, and future contributors know exactly where to go. This repository is the hub that ties them together. PyTorch-Wildlife now lives at [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife), MegaDetector at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector), and everything else is linked in the table below.
+So we made a deliberate decision: break the work into focused, dedicated repositories — one per project — where the code in each repo is concentrated, the ownership is clear, and future contributors know exactly where to go. This repository is the hub that ties them together. PyTorch-Wildlife now lives at [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife), MegaDetector at [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector), and everything else is linked in the table below.
 
 #### Previous versions:
 - [Release notes](https://microsoft.github.io/Biodiversity/releases/release_notes/)
@@ -40,7 +40,7 @@ So we made a deliberate decision: break the work into focused, dedicated reposit
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Overhead imagery detection — point-based wildlife localization from aerial views |
 | [microsoft/MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar) | Sonar-based wildlife detection — processing and feature detection in sidescan sonar imagery |
-| [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) | The collaborative deep learning framework and model zoo for conservation AI |
+| [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) | The collaborative deep learning framework and model zoo for conservation AI |
 | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) | Solar-Powered Acoustic and Remote Recording Observation Watch — AI edge device for remote field deployments |
 
 ## Cite us

--- a/demo/image_detection_colabdemo.ipynb
+++ b/demo/image_detection_colabdemo.ipynb
@@ -888,7 +888,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2024-01-12 17:43:51--  https://github.com/microsoft/CameraTraps/archive/refs/heads/main.zip\n",
+      "--2024-01-12 17:43:51--  https://github.com/microsoft/Biodiversity/archive/refs/heads/main.zip\n",
       "Resolving github.com (github.com)... 140.82.114.3\n",
       "Connecting to github.com (github.com)|140.82.114.3|:443... connected.\n",
       "HTTP request sent, awaiting response... 302 Found\n",
@@ -909,7 +909,7 @@
     }
    ],
    "source": [
-    "!wget -O repo.zip https://github.com/microsoft/CameraTraps/archive/refs/heads/main.zip\n",
+    "!wget -O repo.zip https://github.com/microsoft/Biodiversity/archive/refs/heads/main.zip\n",
     "!unzip -q repo.zip -d ./"
    ]
   },
@@ -922,7 +922,7 @@
    },
    "outputs": [],
    "source": [
-    "tgt_img_path = \"/content/CameraTraps-main/demo/demo_data/imgs/10050028_0.JPG\"\n",
+    "tgt_img_path = \"/content/Biodiversity-main/demo/demo_data/imgs/10050028_0.JPG\"\n",
     "results = detection_model.single_image_detection(tgt_img_path)\n",
     "pw_utils.save_detection_images(results, os.path.join(\".\",\"demo_output\"), overwrite=False)"
    ]
@@ -961,7 +961,7 @@
     }
    ],
    "source": [
-    "tgt_folder_path = \"/content/CameraTraps-main/demo/demo_data/imgs\"\n",
+    "tgt_folder_path = \"/content/Biodiversity-main/demo/demo_data/imgs\"\n",
     "results = detection_model.batch_image_detection(tgt_folder_path, batch_size=16)"
    ]
   },

--- a/demo/video_detection_colabdemo.ipynb
+++ b/demo/video_detection_colabdemo.ipynb
@@ -174,7 +174,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget -O repo.zip https://github.com/microsoft/CameraTraps/archive/refs/heads/main.zip\n",
+    "!wget -O repo.zip https://github.com/microsoft/Biodiversity/archive/refs/heads/main.zip\n",
     "!unzip -q repo.zip -d ./"
    ]
   },
@@ -195,8 +195,8 @@
     "if DEVICE == \"cuda\":\n",
     "    torch.cuda.set_device(0)\n",
     "\n",
-    "SOURCE_VIDEO_PATH = \"/content/CameraTraps-main/demo/demo_data/videos/opossum_example.MP4\"\n",
-    "TARGET_VIDEO_PATH = \"/content/CameraTraps-main/demo/demo_data/videos/opossum_processed.MP4\"\n",
+    "SOURCE_VIDEO_PATH = \"/content/Biodiversity-main/demo/demo_data/videos/opossum_example.MP4\"\n",
+    "TARGET_VIDEO_PATH = \"/content/Biodiversity-main/demo/demo_data/videos/opossum_processed.MP4\"\n",
     "\n",
     "# Verify the checkpoints directory exists to save the model weights if pretrained=True\n",
     "os.makedirs(os.path.join(torch.hub.get_dir(), \"checkpoints\"), exist_ok=True)\n",

--- a/megadetector.md
+++ b/megadetector.md
@@ -11,7 +11,7 @@
 | You want… | Go to |
 |---|---|
 | MegaDetector source, releases, issues, V1–V6 history, benchmarks | **[microsoft/MegaDetector](https://github.com/microsoft/MegaDetector)** |
-| The PyTorch-Wildlife framework that hosts MegaDetector and classifiers | [microsoft/PytorchWildlife](https://github.com/microsoft/PytorchWildlife) |
+| The PyTorch-Wildlife framework that hosts MegaDetector and classifiers | [microsoft/Pytorch-Wildlife](https://github.com/microsoft/Pytorch-Wildlife) |
 | The biodiversity ecosystem umbrella (all repos, one hub) | [microsoft/Biodiversity](https://github.com/microsoft/Biodiversity) |
 | The AI-enabled edge device that runs MegaDetector in the field | [microsoft/SPARROW](https://github.com/microsoft/SPARROW) |
 


### PR DESCRIPTION
## Summary
- `github.com/microsoft/PytorchWildlife` → `github.com/microsoft/Pytorch-Wildlife` (missing dash — flagged by Miao)
- `github.com/microsoft/CameraTraps` → `github.com/microsoft/Biodiversity` (legacy repo name before rename)
- `/content/CameraTraps-main/` path references in Colab demo notebooks → `Biodiversity-main/`

## Files changed
- `README.md` (2 URL refs)
- `megadetector.md` (1 URL ref)
- `PW_FT_classification/README.md` (2 URL refs)
- `demo/image_detection_colabdemo.ipynb` (wget URL + 2 path refs)
- `demo/video_detection_colabdemo.ipynb` (wget URL + 2 path refs)

## Notes
PyPI package name (`pip install PytorchWildlife`, `from PytorchWildlife.models import ...`) is unchanged — that's the correct package name on PyPI.