### PR TITLE
docs: link MegaDetector documentation site from the repo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ So we made a deliberate decision: break the work into focused, dedicated reposit
 
 | Repo | What it is |
 |---|---|
-| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | AI model for detecting animals, people, and vehicles in camera-trap imagery — where it all started |
+| [microsoft/MegaDetector](https://github.com/microsoft/MegaDetector) | AI model for detecting animals, people, and vehicles in camera-trap imagery — where it all started ([documentation](https://microsoft.github.io/MegaDetector/)) |
 | [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) | Bioacoustic AI for biodiversity monitoring — audio classification and species identification from sound |
 | [microsoft/MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) | Camera-trap species classification fine-tuning — adapt classifiers to your own datasets and geographic regions |
 | [microsoft/MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead) | Overhead imagery detection — point-based wildlife localization from aerial views |


### PR DESCRIPTION
Adds a link to the **MegaDetector documentation site** (https://microsoft.github.io/MegaDetector/) next to the existing repo link in the ecosystem table, so readers reach the user guide directly and the docs site gains an inbound link from this repo.

Pairs with the MegaDetector docs/SEO refresh (microsoft/MegaDetector#21, now merged). Single-line, additive change.