### PR TITLE
docs(seo): hub umbrella content + front-matter parity

### DIFF
--- a/docs/bioacoustics.md
+++ b/docs/bioacoustics.md
@@ -1,4 +1,5 @@
 ---
+title: "MegaDetector-Acoustic: Bioacoustic Species Identification"
 description: "MegaDetector-Acoustic: open-source bioacoustic AI for wildlife monitoring. Audio classification, bird detection, and species identification from passive acoustic recordings."
 tags:
   - MegaDetector-Acoustic
@@ -15,10 +16,10 @@ tags:
 ## What's included
 
 - **CLI scripts** for dataset preparation (`prepare_dataset.py`), training (`train.py`), and inference (`inference.py`)
-- **`ResNetClassifier`** — PyTorch Lightning module for spectrogram classification (binary and multiclass)
+- **`ResNetClassifier`**: PyTorch Lightning module for spectrogram classification (binary and multiclass)
 - **Mel-spectrogram preprocessing** with optional GPU acceleration
 - **Annotation readers** (COCO-like JSON), including support for the PteroSet / Raven Pro format
-- **`MD_AudioBirds_V1`** — a pre-trained bird classifier distributed as ONNX for direct inference
+- **`MD_AudioBirds_V1`**: a pre-trained bird classifier distributed as ONNX for direct inference
 
 See the [MegaDetector-Acoustic model zoo](model_zoo/bioacoustics.md) for the released models.
 
@@ -26,16 +27,16 @@ See the [MegaDetector-Acoustic model zoo](model_zoo/bioacoustics.md) for the rel
 
 The end-to-end notebook at [microsoft/MegaDetector-Acoustic](https://github.com/microsoft/MegaDetector-Acoustic) walks through:
 
-1. **Data exploration** — annotation counts, species distribution
-2. **Inference** — run `MD_AudioBirds_V1` on real recordings, visualise predictions vs. ground truth
-3. **Training** — build COCO-style annotations, binary classification (target vs. noise), multiclass classification
+1. **Data exploration**: annotation counts, species distribution
+2. **Inference**: run `MD_AudioBirds_V1` on real recordings, visualise predictions vs. ground truth
+3. **Training**: build COCO-style annotations, binary classification (target vs. noise), multiclass classification
 
 It uses recordings from the [PteroSet](https://zenodo.org/records/19137071) dataset.
 
 ## Projects using this module
 
-- **[PteroSet](https://github.com/microsoft/PteroSet)** — Machine-learning pipeline for detecting and classifying tropical bird vocalisations from passive acoustic monitoring, with leave-one-project-out cross-validation.
-- **[CookInlet_Belugas](https://github.com/microsoft/CookInlet_Belugas)** — Passive acoustic monitoring for endangered Cook Inlet beluga whales. A two-stage pipeline covering cetacean signal detection and multi-species classification (beluga, humpback, killer whale), plus an active-learning loop for domain adaptation.
+- **[PteroSet](https://github.com/microsoft/PteroSet)**: Machine-learning pipeline for detecting and classifying tropical bird vocalisations from passive acoustic monitoring, with leave-one-project-out cross-validation.
+- **[CookInlet_Belugas](https://github.com/microsoft/CookInlet_Belugas)**: Passive acoustic monitoring for endangered Cook Inlet beluga whales. A two-stage pipeline covering cetacean signal detection and multi-species classification (beluga, humpback, killer whale), plus an active-learning loop for domain adaptation.
 
 ## Install
 

--- a/docs/build_mkdocs.md
+++ b/docs/build_mkdocs.md
@@ -1,4 +1,5 @@
 ---
+title: "Build the PyTorch-Wildlife Documentation Site"
 description: "How to build and deploy the PyTorch-Wildlife MkDocs documentation site locally and to GitHub Pages."
 tags:
   - PyTorch-Wildlife

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,4 +1,5 @@
 ---
+title: "Cite PyTorch-Wildlife and MegaDetector"
 description: "Cite PyTorch-Wildlife and MegaDetector in your research. BibTeX entries for Hernandez et al. 2024 (PyTorch-Wildlife) and Beery et al. 2019 (MegaDetector)."
 tags:
   - cite PyTorch-Wildlife

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,4 +1,5 @@
 ---
+title: "Contributing to PyTorch-Wildlife"
 description: "Contribute to PyTorch-Wildlife: guidelines for submitting issues, pull requests, and new models to the Microsoft Biodiversity open-source conservation AI platform."
 tags:
   - contribute PyTorch-Wildlife
@@ -19,7 +20,7 @@ Thanks for your interest in collaborating on PyTorch-Wildlife! Here you can find
 4. 🤝 Once we get your comments, we’ll move the issue to **“In progress”** and assign you as the collaborator.  
 5. 🛠 Work on it at your own pace, and when it’s ready, submit a pull request to the **`Collaborations`** branch. 
 6. 🔍 We’ll review your PR, run tests, and merge it into our **pre‑release** branch ahead of the next version.
-7. 🎉 After merging, we’ll mark the issue/task as **“Done”** and credit your contribution in the release notes—thank you!
+7. 🎉 After merging, we’ll mark the issue/task as **“Done”** and credit your contribution in the release notes. Thank you!
 
 ---
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,5 +1,6 @@
 ---
-description: "PyTorch-Wildlife contributors — the researchers and engineers behind the Microsoft AI for Good Lab biodiversity tools."
+title: "PyTorch-Wildlife Contributors"
+description: "PyTorch-Wildlife contributors: the researchers and engineers behind the Microsoft AI for Good Lab biodiversity tools."
 tags:
   - PyTorch-Wildlife
   - contributors

--- a/docs/core_features.md
+++ b/docs/core_features.md
@@ -1,4 +1,5 @@
 ---
+title: "PyTorch-Wildlife Core Features: Detection, Classification, and Model Zoo"
 description: "PyTorch-Wildlife core features: unified framework for wildlife AI combining detection models, pre-trained weights, datasets, and utilities for conservation research."
 tags:
   - PyTorch-Wildlife features

--- a/docs/ecosystem-standards.md
+++ b/docs/ecosystem-standards.md
@@ -1,0 +1,80 @@
+---
+title: "Ecosystem Documentation Standards for Microsoft Biodiversity Projects"
+description: "The shared documentation standards every Microsoft Biodiversity ecosystem repo follows: site structure, metadata, structured data, cross-linking, and topic ownership."
+tags:
+  - documentation standards
+  - open source conservation AI
+  - Microsoft biodiversity AI
+---
+
+# Ecosystem Documentation Standards
+
+Every project in the Microsoft Biodiversity ecosystem publishes its documentation the same way, so
+the sites read as one family and each ranks as the canonical source for its own topic. This page is
+the reference for bringing a new repo up to that standard, distilled from the work on
+[MegaDetector](https://microsoft.github.io/MegaDetector/), which sets the pattern.
+
+## Site structure
+
+Each repo ships a MkDocs Material site under `docs/`, deployed to
+`https://microsoft.github.io/<Repo>/`. Use a single `<h1>` per page that matches the page title,
+keep a clear navigation tree, and give every concept its own page rather than one long README. A
+docs homepage leads with the value proposition in the first sentence, then links out to the
+detailed pages.
+
+## Page metadata
+
+Every content page carries front matter:
+
+- a `title` that is unique and leads with the page's primary topic,
+- a `description` of roughly 110 to 160 characters that reads as a search snippet,
+- a `tags` list scoped to that page's topic.
+
+`mkdocs.yml` sets `site_url` and a keyword-rich `site_description`. Descriptions stay distinct from
+one repo to the next so previews and snippets do not blur together.
+
+## Structured data and social cards
+
+A theme override (`overrides/main.html`) injects JSON-LD, gated per page so each block only appears
+where it belongs. A homepage carries a connected graph: a `WebSite` node, the project as
+`SoftwareSourceCode` (the hub uses `CollectionPage` plus an `ItemList` of the projects), and the Lab
+as the publishing `Organization`, cross-linked by `@id`. Add `sameAs` links to the GitHub repo and
+any package, paper, or model page so search engines can resolve the project as one entity. Interior
+pages carry a `BreadcrumbList`, and pages with a FAQ carry a `FAQPage`. Every page also emits Open
+Graph and Twitter Card tags with an absolute share image.
+
+## Build and freshness
+
+The site uses the `callouts` plugin so GitHub-style admonitions render in both the README and the
+docs, and `git-revision-date-localized` to show a real last-updated date. The deploy workflow checks
+out full history (`fetch-depth: 0`) so those dates are accurate. A self-hosted favicon and logo live
+in `docs/assets/` rather than loading from an external host.
+
+## Cross-linking and topic ownership
+
+The hub and the projects link to each other so the ecosystem reads as a connected graph rather than
+separate sites:
+
+- The hub links out to every project with a topic-specific anchor.
+- Each project links back to the hub with an umbrella anchor.
+- Each project carries a short "related projects" section, with one sentence on how each neighbor
+  differs, rather than an identical block of links on every page.
+
+Topic ownership keeps the projects from competing with each other. The hub owns the umbrella terms
+for Microsoft biodiversity AI and open-source conservation AI. Each project owns its own area:
+
+| Project | Owns |
+|---|---|
+| [MegaDetector](https://microsoft.github.io/MegaDetector/) | camera-trap image detection and blank-frame filtering |
+| [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/) | terrestrial bioacoustic classification and species identification from sound |
+| [SPARROW](https://microsoft.github.io/SPARROW/) | solar-powered edge hardware, field deployment, and remote connectivity |
+| [PyTorch-Wildlife](https://microsoft.github.io/Pytorch-Wildlife/) | the deep learning framework, model zoo, training, and inference |
+
+When one project's page mentions a topic another project owns, it links to that owner rather than
+trying to rank for the term itself.
+
+## Writing
+
+Documentation is written to be read by people. Keep prose specific and sourced to the repository,
+vary sentence structure, and avoid filler. New pages add real material rather than restating the
+README. Claims about accuracy, scale, or performance point to a source or are softened.

--- a/docs/ecosystem-standards.md
+++ b/docs/ecosystem-standards.md
@@ -66,7 +66,7 @@ for Microsoft biodiversity AI and open-source conservation AI. Each project owns
 | Project | Owns |
 |---|---|
 | [MegaDetector](https://microsoft.github.io/MegaDetector/) | camera-trap image detection and blank-frame filtering |
-| [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/) | terrestrial bioacoustic classification and species identification from sound |
+| MegaDetector-Acoustic (documentation coming soon) | terrestrial bioacoustic classification and species identification from sound |
 | [SPARROW](https://microsoft.github.io/SPARROW/) | solar-powered edge hardware, field deployment, and remote connectivity |
 | [PyTorch-Wildlife](https://microsoft.github.io/Pytorch-Wildlife/) | the deep learning framework, model zoo, training, and inference |
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,91 @@
+---
+title: "The Microsoft Biodiversity Ecosystem: Open-Source Conservation AI Projects"
+description: "A guide to the Microsoft AI for Good Lab biodiversity ecosystem: which open-source conservation AI project fits camera traps, audio, field devices, or model development."
+tags:
+  - Microsoft biodiversity AI
+  - open source conservation AI
+  - wildlife monitoring AI tools
+  - AI for Good biodiversity
+  - conservation AI
+---
+
+# The Microsoft Biodiversity Ecosystem
+
+The Microsoft AI for Good Lab maintains a family of open-source projects for biodiversity
+monitoring and conservation. Each one owns a distinct part of the workflow, from detecting
+animals in imagery to classifying sounds, deploying field hardware, and building custom models.
+This page is the directory for the ecosystem and a guide to picking the right starting point.
+
+## Which project should I use?
+
+Start from what you already have or what you are trying to build.
+
+- **I have camera-trap photos and want to find the animals in them.** Use
+  [MegaDetector](https://microsoft.github.io/MegaDetector/), the detector that locates animals,
+  people, and vehicles in camera-trap images and clears the empty frames out of your review queue.
+- **I have audio recordings and want to identify what is calling.** Use
+  [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/) for terrestrial
+  bioacoustic classification and species identification from sound.
+- **I am deploying a sensor in the field and need it to run on its own power.** Use
+  [SPARROW](https://microsoft.github.io/SPARROW/), the solar-powered edge device that runs these
+  models on site and sends results back over remote connectivity.
+- **I want to build, train, or integrate conservation models in my own code.** Use
+  [PyTorch-Wildlife](https://microsoft.github.io/Pytorch-Wildlife/), the deep learning framework
+  and model zoo that ties the ecosystem together in Python.
+- **I want to adapt a species classifier to my own region or dataset.** Use
+  [MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier) to fine-tune
+  classification on top of detections.
+
+## Projects
+
+### Detection
+
+- **[MegaDetector](https://microsoft.github.io/MegaDetector/)** is where the ecosystem started.
+  It detects animals, people, and vehicles in camera-trap imagery and filters blank frames, which
+  removes the bulk of manual review on large datasets. See the
+  [camera-trap image detection documentation](https://microsoft.github.io/MegaDetector/) for run
+  paths, the model zoo, and output format.
+- **[MegaDetector-Overhead](https://github.com/microsoft/MegaDetector-Overhead)** brings detection
+  to aerial and drone imagery with point-based wildlife localization from overhead views.
+- **[MegaDetector-Sonar](https://github.com/microsoft/MegaDetector-Sonar)** extends detection to
+  sidescan sonar imagery for underwater wildlife surveys.
+
+### Audio
+
+- **[MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/)** handles the
+  audio side of monitoring: classifying calls and identifying terrestrial species from sound
+  recordings, the bioacoustic counterpart to image-based detection.
+
+### Classification
+
+- **[MegaDetector-Classifier](https://github.com/microsoft/MegaDetector-Classifier)** fine-tunes
+  species classification on top of detections, so you can adapt a model to the species and regions
+  in your own data.
+
+### Field hardware
+
+- **[SPARROW](https://microsoft.github.io/SPARROW/)**, the Solar-Powered Acoustic and Remote
+  Recording Observation Watch, is the edge device for remote deployments. It captures imagery and
+  audio, runs ecosystem models on site, and reports results back over satellite or cellular links.
+
+### Framework
+
+- **[PyTorch-Wildlife](https://microsoft.github.io/Pytorch-Wildlife/)** is the collaborative deep
+  learning framework and model zoo for conservation AI. It loads detection and classification
+  models in a few lines of Python and is the integration point for building on top of the ecosystem.
+
+## How the projects fit together
+
+A typical pipeline moves from capture to insight. A field unit such as SPARROW collects imagery
+and audio in a remote site. MegaDetector finds the animals in the images and discards empty frames.
+MegaDetector-Classifier or a model from the PyTorch-Wildlife zoo names the species in those
+detections, while MegaDetector-Acoustic does the same for the audio. PyTorch-Wildlife is the common
+framework that runs each model and lets you assemble these steps into your own workflow.
+
+## Get involved
+
+The projects share a home in the [Microsoft Biodiversity organization](https://github.com/microsoft/Biodiversity)
+and a community on [Discord](https://discord.gg/TeEVxzaYtm). See the list of teams already using
+these tools on the [collaborators page](collaborators.md), and the
+[ecosystem documentation standards](ecosystem-standards.md) if you are bringing a new project into
+the family.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -24,7 +24,7 @@ Start from what you already have or what you are trying to build.
   [MegaDetector](https://microsoft.github.io/MegaDetector/), the detector that locates animals,
   people, and vehicles in camera-trap images and clears the empty frames out of your review queue.
 - **I have audio recordings and want to identify what is calling.** Use
-  [MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/) for terrestrial
+  MegaDetector-Acoustic (documentation coming soon) for terrestrial
   bioacoustic classification and species identification from sound.
 - **I am deploying a sensor in the field and need it to run on its own power.** Use
   [SPARROW](https://microsoft.github.io/SPARROW/), the solar-powered edge device that runs these
@@ -52,7 +52,7 @@ Start from what you already have or what you are trying to build.
 
 ### Audio
 
-- **[MegaDetector-Acoustic](https://microsoft.github.io/MegaDetector-Acoustic/)** handles the
+- **MegaDetector-Acoustic (documentation coming soon)** handles the
   audio side of monitoring: classifying calls and identifying terrestrial species from sound
   recordings, the bioacoustic counterpart to image-based detection.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,9 @@ tags:
 ## 👋 Welcome to PyTorch-Wildlife
 **PyTorch-Wildlife** is an AI platform designed for the AI for Conservation community to create, modify, and share powerful AI conservation models. It allows users to directly load a variety of models including [MegaDetector](https://github.com/microsoft/MegaDetector), [DeepFaune](https://www.deepfaune.cnrs.fr/en/), and [HerdNet](https://github.com/Alexandre-Delplanque/HerdNet) from our ever expanding [model zoo](model_zoo/megadetector.md) for both animal detection and classification.
 
-Our scope now spans well beyond camera-trap imagery — we have active work in [MegaDetector-Acoustic](bioacoustics.md) for bioacoustic species identification, [MegaDetector-Overhead](model_zoo/other_detectors.md) for aerial wildlife detection, and edge computing for remote field deployments.
+Our scope now spans well beyond camera-trap imagery, with active work in [MegaDetector-Acoustic](bioacoustics.md) for bioacoustic species identification, [MegaDetector-Overhead](model_zoo/other_detectors.md) for aerial wildlife detection, and edge computing for remote field deployments.
+
+**New here?** The [Microsoft Biodiversity ecosystem guide](ecosystem.md) walks through every open-source project in the family and helps you pick the right one for camera-trap images, audio, field hardware, or model development. See who is already using these tools on the [collaborators page](collaborators.md).
 
 > **Coming from an older version?** OWL is now **MegaDetector-Overhead**, the bioacoustics module is now **MegaDetector-Acoustic**, and the repo has moved from `microsoft/CameraTraps` to `microsoft/Biodiversity` (old links redirect automatically). See the [full naming changes](releases/release_notes.md#naming-changes) in the v1.3.0 release notes.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,5 @@
 ---
+title: "Install PyTorch-Wildlife: pip, conda, and Docker Setup"
 description: "Install PyTorch-Wildlife for camera trap AI and wildlife detection. Supports conda, pip, and Docker on Windows, macOS, and Linux with optional CUDA GPU acceleration."
 tags:
   - PyTorch-Wildlife installation

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,5 @@
 ---
+title: "PyTorch-Wildlife License"
 description: "PyTorch-Wildlife license information: MIT for the core package and utilities. Model-specific licenses (AGPL-3.0, CC BY-SA) are listed in the model zoo."
 tags:
   - PyTorch-Wildlife license

--- a/docs/megadetector.md
+++ b/docs/megadetector.md
@@ -1,4 +1,5 @@
 ---
+title: "MegaDetector in PyTorch-Wildlife: Camera-Trap Animal Detection"
 description: "MegaDetector: AI model for detecting animals, people, and vehicles in camera-trap images. MegaDetectorV5 and MegaDetectorV6 available via PyTorch-Wildlife."
 tags:
   - MegaDetector

--- a/docs/pw_engine_overview.md
+++ b/docs/pw_engine_overview.md
@@ -1,9 +1,10 @@
 ---
-description: "PW-Engine: Rust-based inference core for PyTorch-Wildlife. Powers SPARROW Studio with sub-second cold starts, ONNX Runtime, and HTTP/CLI/Python/C-FFI surfaces."
+title: "PW-Engine: Rust Inference Core for PyTorch-Wildlife"
+description: "PW-Engine: Rust-based inference core for PyTorch-Wildlife. Powers SPARROW with sub-second cold starts, ONNX Runtime, and HTTP/CLI/Python/C-FFI surfaces."
 tags:
   - PW-Engine
   - PyTorch-Wildlife
-  - SPARROW Studio
+  - SPARROW
   - ONNX Runtime
   - wildlife AI inference
   - conservation technology
@@ -15,25 +16,25 @@ tags:
 
 **Status:** Preview. Inference surfaces are feature-complete; a data-management layer is the next milestone.
 
-**In one sentence:** PW-Engine (full name: PyTorch-Wildlife Engine) is a Rust-based inference engine and HTTP service that runs the PyTorch-Wildlife model set, powers SPARROW Studio, and can be embedded as the backend of any inference-heavy application.
+**In one sentence:** PW-Engine (full name: PyTorch-Wildlife Engine) is a Rust-based inference engine and HTTP service that runs the PyTorch-Wildlife model set, powers SPARROW, and can be embedded as the backend of any inference-heavy application.
 
 ---
 
 ## Why
 
-PyTorch-Wildlife today runs PyTorch end-to-end. That is right for research — it keeps model code, training, and fine-tuning in one place — but it pays real deployment costs: multi-second cold starts, multi-GB Docker images, single-process concurrency limits, and no practical path to integrate with serious UI or desktop applications. Anything non-Python has to shell out to a Python process.
+PyTorch-Wildlife today runs PyTorch end-to-end. That is right for research, since it keeps model code, training, and fine-tuning in one place, but it pays real deployment costs: multi-second cold starts, multi-GB Docker images, single-process concurrency limits, and no practical path to integrate with serious UI or desktop applications. Anything non-Python has to shell out to a Python process.
 
-To let UI developers — SPARROW Studio and anyone else — get both production-level latency and model-agnostic compatibility, we're building PW-Engine as a separate inference layer.
+To let UI developers (SPARROW and anyone else) get both production-level latency and model-agnostic compatibility, we're building PW-Engine as a separate inference layer.
 
 | Prior deployment shape | Cause | PW-Engine response |
 |---|---|---|
 | Multi-second cold start | Python interpreter + server initialization | Sub-second cold start on GPU |
 | Multi-GB Docker images | Python + CUDA bloat | CPU image ~163 MB; GPU image ~4 GB |
 | GIL-bound concurrency | Single-process Python worker | Async HTTP server (axum/tokio); per-model serialization, multi-model concurrent |
-| Hard to embed in UI / desktop | PyTorch process is the only runtime; no FFI | Rust core with HTTP / CLI / Python / C-FFI surfaces — UI devs integrate natively |
+| Hard to embed in UI / desktop | PyTorch process is the only runtime; no FFI | Rust core with HTTP / CLI / Python / C-FFI surfaces, so UI devs integrate natively |
 | Adding a model needs code changes | Hardcoded PyTorch model adapters | Drop an ONNX file + a manifest entry into the model directory |
 
-Because PyTorch-Wildlife today does not use ONNX at runtime, moving inference to PW-Engine (Rust + ONNX Runtime) is also a speed gain on top of the deployment-shape improvements above — not a wash against an ONNX baseline.
+Because PyTorch-Wildlife today does not use ONNX at runtime, moving inference to PW-Engine (Rust + ONNX Runtime) is also a speed gain on top of the deployment-shape improvements above, not a wash against an ONNX baseline.
 
 ---
 
@@ -62,13 +63,13 @@ PW-Engine is a Rust core library with four consumption surfaces:
 
              +---- C FFI (generated header) ----+
              v                                  v
-        SPARROW Studio                      Other native
+        SPARROW                      Other native
         Local (C#/P-Invoke)                 integrators
 ```
 
 **Runtime:** ONNX Runtime (CPU or GPU). No PyTorch at inference time.
 
-**Model zoo:** PW-Engine targets full compatibility with the PyTorch-Wildlife model zoo. Adding a model is a manifest change plus an ONNX file in the model directory — no engine code change required.
+**Model zoo:** PW-Engine targets full compatibility with the PyTorch-Wildlife model zoo. Adding a model is a manifest change plus an ONNX file in the model directory, with no engine code change required.
 
 ---
 
@@ -78,11 +79,11 @@ Pick the surface that matches your stack.
 
 | You are a… | Surface you use | Notes |
 |---|---|---|
-| Conservation user | No direct use — you interact via SPARROW Studio | Install the MSI; PW-Engine runs underneath |
+| Conservation user | No direct use; you interact via SPARROW | Install the MSI; PW-Engine runs underneath |
 | Existing Python user (`import PytorchWildlife`) | PyO3 bindings | Same API shape; drop-in |
 | Web/cloud deployer running an inference server | Docker HTTP container | `docker run`; call `/v1/detect` |
-| Laptop researcher | CLI — single static binary, ~35 MB | Invoke the CLI against a local image/audio file |
-| Desktop app developer (Windows/.NET first; Mac/Linux ports in progress) | C FFI / C# bindings | Same integration path SPARROW Studio Local uses |
+| Laptop researcher | CLI: single static binary, ~35 MB | Invoke the CLI against a local image/audio file |
+| Desktop app developer (Windows/.NET first; Mac/Linux ports in progress) | C FFI / C# bindings | Same integration path SPARROW Local uses |
 | Institutional / platform owner | Any combination | One inference implementation across desktop, server, and embedded |
 
 **Custom models:** drop an ONNX file plus a manifest entry into the model directory. No engine code change.
@@ -107,7 +108,7 @@ Reliability hardening for long-running GPU workloads is in progress.
 
 **Next milestone:** data-management sidecar.
 
-**Availability:** preview today via the SPARROW Studio beta.
+**Availability:** preview today via the SPARROW beta.
 
 ---
 
@@ -115,11 +116,11 @@ Reliability hardening for long-running GPU workloads is in progress.
 
 - **Does this replace PyTorch-Wildlife?**
 
-No. The Python PyTorch-Wildlife package remains the user-facing interface for training, fine-tuning, and research workflows. PW-Engine is the inference backend — over time, PyTorch-Wildlife itself will sit on top of PW-Engine rather than running PyTorch inference directly.
+No. The Python PyTorch-Wildlife package remains the user-facing interface for training, fine-tuning, and research workflows. PW-Engine is the inference backend. Over time, PyTorch-Wildlife itself will sit on top of PW-Engine rather than running PyTorch inference directly.
 
 - **When can I try it?**
 
-Through the SPARROW Studio beta (Windows MSI). We will update the beta in the next few weeks with PW-Engine as the core.
+Through the SPARROW beta (Windows MSI). We will update the beta in the next few weeks with PW-Engine as the core.
 
 - **Will my existing Python code break?**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ theme:
 nav:
   - PyTorch-Wildlife:
     - Overview: index.md
+    - The Ecosystem: ecosystem.md
     - Core Features: core_features.md
     - MegaDetector: megadetector.md
     - MegaDetector-Acoustic: bioacoustics.md
@@ -99,6 +100,7 @@ nav:
     - BoquilaHUB: demo_and_ui/boquilahub.md
   - Contribute:
     - Contribute Guidelines: contribute.md
+    - Documentation Standards: ecosystem-standards.md
     - License: license.md
     - Developer Guide: build_mkdocs.md
   - Reference - Code API:


### PR DESCRIPTION
## What

Additive content layer for the Biodiversity hub (stacked on the infra/schema PR #653; **base will retarget to main when #653 merges**).

### New pages
- **`docs/ecosystem.md`** — the ecosystem directory + a "which project should I use?" decision guide, with topic-specific anchors linking out to each project's documentation site (MegaDetector, MegaDetector-Acoustic, SPARROW, PyTorch-Wildlife). Targets the hub's umbrella keywords (Microsoft biodiversity AI, open source conservation AI). Cluster-cohesion win.
- **`docs/ecosystem-standards.md`** — the shared documentation standards every ecosystem repo follows (site structure, metadata, structured data, cross-linking, topic ownership), so new repos replicate the gold-standard pattern.

### Other
- Both pages added to nav; homepage now surfaces the ecosystem + collaborators with controlled anchors.
- `title:` front-matter added to 10 hand-written pages (front-matter parity).
- Removed stale "SPARROW Studio" naming and em-dashes from every touched page.

## Verification
- `mkdocs build` succeeds; both new pages render with correct titles, interior BreadcrumbList, and resolving lane links.
- Em-dash gate: clean across all 13 touched pages.
- AI-tells linter: the only flags are pre-existing HTML/markup boilerplate (badge row, banner div, example-image captions, org-list items); the new prose pages are unflagged.

## ⚠️ Positioning flag for @zhmiao (not addressed here, by design)
The hub repo (microsoft/Biodiversity) **hosts the PytorchWildlife package + setup.py** and its homepage is titled "Welcome to PyTorch-Wildlife", while a **separate microsoft/Pytorch-Wildlife repo** also embodies the framework. This creates a hub-vs-sub-repo identity overlap and "PyTorch Wildlife" keyword cannibalization. Reframing the hub homepage as a pure umbrella is **deferred** pending a team decision on which repo owns the framework identity. This PR is additive only and does not touch that positioning.

Part of the cluster SEO-parity work (ADO Epic 506340).