### PR TITLE
ci: deploy docs when overrides/ changes + add manual trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,8 +6,10 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'overrides/**'
       - 'mkdocs.yml'
       - 'docs-requirements.txt'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Problem
The `Deploy MkDocs site` workflow triggers on pushes to `main` that touch `docs/**`, `mkdocs.yml`, or `docs-requirements.txt`. The theme override `overrides/main.html` — which holds the JSON-LD, Open Graph, and social-card meta — is **not** watched. An overrides-only SEO PR would merge to main but never trigger a deploy, so the change would never go live.

## Fix
- Add `overrides/**` to the push path filter, so theme/SEO override changes deploy.
- Add a `workflow_dispatch:` trigger, so a stranded change can be redeployed manually without an empty commit.