### PR TITLE
harden grado serve and bump up python floor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,31 @@
-FROM python:3.8-slim  
-  
-ARG GRADIO_SERVER_NAME="0.0.0.0"  
-ENV GRADIO_SERVER_NAME=${GRADIO_SERVER_NAME}  
-  
-ARG GRADIO_SERVER_PORT="80"  
-ENV GRADIO_SERVER_PORT=${GRADIO_SERVER_PORT}  
-      
-RUN apt-get update && \    
-    apt-get install -y --no-install-recommends  \ 
+# SECURITY: Python 3.8 is EOL (October 2024) and pins gradio below the CVE fix
+# line. Base image bumped to 3.11-slim so pip can resolve gradio>=4.44.1 which
+# includes the arbitrary-file-read fixes exercised by demo/gradio_demo.py.
+FROM python:3.11-slim
+
+# NOTE: GRADIO_SERVER_NAME defaults to 0.0.0.0 so the container can serve on
+# its published port. Only publish that port on a trusted network or behind
+# an authenticating reverse proxy — the Gradio demo has no built-in auth.
+ARG GRADIO_SERVER_NAME="0.0.0.0"
+ENV GRADIO_SERVER_NAME=${GRADIO_SERVER_NAME}
+
+ARG GRADIO_SERVER_PORT="80"
+ENV GRADIO_SERVER_PORT=${GRADIO_SERVER_PORT}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends  \
     libgl1-mesa-glx \
     libglib2.0-0 \
     ffmpeg && \
-    apt-get clean && \    
-    rm -rf /var/lib/apt/lists/* 
-    
-WORKDIR /app    
-    
-COPY . /app    
-     
-RUN rm -rf /tmp/*    
-    
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . /app
+
+RUN rm -rf /tmp/*
+
 RUN pip install --no-cache-dir PytorchWildlife
 
 EXPOSE 80

--- a/demo/gradio_demo.py
+++ b/demo/gradio_demo.py
@@ -1,19 +1,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-""" Gradio Demo for image detection"""
+""" Gradio Demo for image detection.
+
+SECURITY NOTE: this file is a *demo*, intended for local development against a
+trusted network. Do NOT expose it directly to untrusted networks. The hardened
+`demo.launch(...)` call at the bottom of this file disables the public
+`share=True` tunnel and restricts Gradio's file-serving surface, but you should
+still front the demo with an authenticating reverse proxy if remote users need
+access. See the security section in the README for details.
+"""
 
 # Importing necessary basic libraries and modules
 import os
+import tempfile
 
-# PyTorch imports 
+# PyTorch imports
 import torch
 from torch.utils.data import DataLoader
 
 # Importing the model, dataset, transformations and utility functions from PytorchWildlife
 from PytorchWildlife.models import detection as pw_detection
 from PytorchWildlife import utils as pw_utils
- 
+
 # Importing basic libraries
 import shutil
 import time
@@ -27,7 +36,7 @@ import ast
 # Importing the models, dataset, transformations, and utility functions from PytorchWildlife
 from PytorchWildlife.models import classification as pw_classification
 from PytorchWildlife.data import transforms as pw_trans
-from PytorchWildlife.data import datasets as pw_data 
+from PytorchWildlife.data import datasets as pw_data
 
 # Setting the device to use for computations ('cuda' indicates GPU)
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -35,13 +44,15 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 dot_annotator = sv.DotAnnotator(radius=6)
 box_annotator = sv.BoxAnnotator(thickness=4)
 lab_annotator = sv.LabelAnnotator(text_color=sv.Color.BLACK, text_thickness=4, text_scale=2)
-# Create a temp folder
-os.makedirs(os.path.join("..","temp"), exist_ok=True) # ASK: Why do we need this?
+# SECURITY: use a per-process tempdir instead of a shared "../temp" path.
+# This keeps demo scratch files inside a single directory we can whitelist via
+# Gradio's `allowed_paths`, and avoids traversal outside the demo working dir.
+TEMP_DIR = tempfile.mkdtemp(prefix="pw_gradio_demo_")
 
 # Initializing the detection and classification models
 detection_model = None
 classification_model = None
-    
+
 # Defining functions for different detection scenarios
 def load_models(det, version, clf, wpath=None, wclass=None):
 
@@ -65,7 +76,7 @@ def load_models(det, version, clf, wpath=None, wclass=None):
     if clf != "None":
         # Create an exception for custom weights
         if clf == "CustomWeights":
-            if (wpath is not None) and (wclass is not None): 
+            if (wpath is not None) and (wclass is not None):
                 wclass = ast.literal_eval(wclass)
                 classification_model = pw_classification.__dict__[clf](weights=wpath, class_names=wclass, device=DEVICE)
         else:
@@ -101,7 +112,7 @@ def single_image_detection(input_img, det_conf_thres, clf_conf_thres, img_index=
         results_det = detection_model.single_image_detection(input_img,
                                                              img_path=img_index,
                                                              det_conf_thres = det_conf_thres)
-    
+
     if classification_model is not None:
         labels = []
         for i, (xyxy, det_id) in enumerate(zip(results_det["detections"].xyxy, results_det["detections"].class_id)):
@@ -128,7 +139,7 @@ def single_image_detection(input_img, det_conf_thres, clf_conf_thres, img_index=
 
 def batch_detection(zip_file, timelapse, det_conf_thres):
     """Perform detection on a batch of images from a zip file and return path to results JSON.
-    
+
     Args:
         zip_file (File): Zip file containing images.
         det_conf_thres (float): Confidence threshold for detection.
@@ -139,7 +150,7 @@ def batch_detection(zip_file, timelapse, det_conf_thres):
         json_save_path (str): Path to the JSON file containing detection results.
     """
     # Clean the temp folder if it contains files
-    extract_path = os.path.join("..","temp","zip_upload")
+    extract_path = os.path.join(TEMP_DIR, "zip_upload")
     if os.path.exists(extract_path):
         shutil.rmtree(extract_path)
     os.makedirs(extract_path)
@@ -149,14 +160,14 @@ def batch_detection(zip_file, timelapse, det_conf_thres):
         zfile.extractall(extract_path)
         # Check the contents of the extracted folder
         extracted_files = os.listdir(extract_path)
-        
+
     if len(extracted_files) == 1 and os.path.isdir(os.path.join(extract_path, extracted_files[0])):
         tgt_folder_path = os.path.join(extract_path, extracted_files[0])
     else:
         tgt_folder_path = extract_path
     # If the detection model is HerdNet set batch_size to 1
     if detection_model.__class__.__name__.__contains__("HerdNet"):
-        det_results = detection_model.batch_image_detection(tgt_folder_path, batch_size=1, det_conf_thres=det_conf_thres, id_strip=tgt_folder_path) 
+        det_results = detection_model.batch_image_detection(tgt_folder_path, batch_size=1, det_conf_thres=det_conf_thres, id_strip=tgt_folder_path)
     else:
         det_results = detection_model.batch_image_detection(tgt_folder_path, batch_size=16, det_conf_thres=det_conf_thres, id_strip=tgt_folder_path)
 
@@ -166,7 +177,7 @@ def batch_detection(zip_file, timelapse, det_conf_thres):
             transform=pw_trans.Classification_Inference_Transform(target_size=224),
             path_head=tgt_folder_path
         )
-        clf_loader = DataLoader(clf_dataset, batch_size=32, shuffle=False, 
+        clf_loader = DataLoader(clf_dataset, batch_size=32, shuffle=False,
                                 pin_memory=True, num_workers=4, drop_last=False)
         clf_results = classification_model.batch_image_classification(clf_loader, id_strip=tgt_folder_path)
         if timelapse:
@@ -188,14 +199,14 @@ def batch_detection(zip_file, timelapse, det_conf_thres):
             pw_utils.save_detection_timelapse_json(det_results, json_save_path, categories=detection_model.CLASS_NAMES)
         elif detection_model.__class__.__name__.__contains__("HerdNet"):
             pw_utils.save_detection_json_as_dots(det_results, json_save_path, categories=detection_model.CLASS_NAMES)
-        else: 
+        else:
             pw_utils.save_detection_json(det_results, json_save_path, categories=detection_model.CLASS_NAMES)
 
     return json_save_path
 
 def batch_path_detection(tgt_folder_path, det_conf_thres):
     """Perform detection on a batch of images from a zip file and return path to results JSON.
-    
+
     Args:
         tgt_folder_path (str): path to the folder containing the images.
         det_conf_thres (float): Confidence threshold for detection.
@@ -215,7 +226,7 @@ def batch_path_detection(tgt_folder_path, det_conf_thres):
 
 def video_detection(video, det_conf_thres, clf_conf_thres, target_fps, codec):
     """Perform detection on a video and return path to processed video.
-    
+
     Args:
         video (str): Video source path.
         det_conf_thres (float): Confidence threshold for detection.
@@ -227,9 +238,9 @@ def video_detection(video, det_conf_thres, clf_conf_thres, target_fps, codec):
                                                  img_index=index,
                                                  det_conf_thres=det_conf_thres,
                                                  clf_conf_thres=clf_conf_thres)
-        return annotated_frame 
-    
-    target_path = os.path.join("..","temp","video_detection.mp4")
+        return annotated_frame
+
+    target_path = os.path.join(TEMP_DIR, "video_detection.mp4")
     pw_utils.process_video(source_path=video, target_path=target_path,
                            callback=callback, target_fps=int(target_fps), codec=codec)
     return target_path
@@ -243,15 +254,15 @@ with gr.Blocks() as demo:
             ["None", "MegaDetectorV5", "MegaDetectorV6", "HerdNet General", "HerdNet Ennedi"],
             label="Detection model",
             info="Will add more detection models!",
-            value="None" # Default 
+            value="None" # Default
         )
-        det_version = gr.Dropdown(  
-            ["None"],  
-            label="Model version",  
+        det_version = gr.Dropdown(
+            ["None"],
+            label="Model version",
             info="Select the version of the model",
             value="None",
         )
-    
+
     with gr.Column():
         clf_drop = gr.Dropdown(
             ["None", "AI4GOpossum", "AI4GAmazonRainforest", "AI4GSnapshotSerengeti", "CustomWeights"],
@@ -265,15 +276,15 @@ with gr.Blocks() as demo:
         custom_weights_class = gr.Textbox(label="Custom Weights Class", visible=False, interactive=True, placeholder="{1:'ocelot', 2:'cow', 3:'bear'}")
         load_but = gr.Button("Load Models!")
         load_out = gr.Text("NO MODEL LOADED!!", label="Loaded models:")
-   
-    def update_ui_elements(det_model):  
-        if det_model == "MegaDetectorV6":  
-            return gr.Dropdown(choices=["MDV6-yolov9-c", "MDV6-yolov9-e", "MDV6-yolov10-c", "MDV6-yolov10-e", "MDV6-rtdetr-c", "MDV6-yolov9-c-mit", "MDV6-yolov9-e-mit", "MDV6-rtdetr-c-apache", "MDV6-rtdetr-e-apache"], interactive=True, label="Model version", value="MDV6-yolov9e"), gr.update(visible=True)  
-        elif det_model == "MegaDetectorV5":  
+
+    def update_ui_elements(det_model):
+        if det_model == "MegaDetectorV6":
+            return gr.Dropdown(choices=["MDV6-yolov9-c", "MDV6-yolov9-e", "MDV6-yolov10-c", "MDV6-yolov10-e", "MDV6-rtdetr-c", "MDV6-yolov9-c-mit", "MDV6-yolov9-e-mit", "MDV6-rtdetr-c-apache", "MDV6-rtdetr-e-apache"], interactive=True, label="Model version", value="MDV6-yolov9e"), gr.update(visible=True)
+        elif det_model == "MegaDetectorV5":
             return gr.Dropdown(choices=["a", "b"], interactive=True, label="Model version", value="a"), gr.update(visible=True)
         else:
-            return gr.Dropdown(choices=["None"], interactive=True, label="Model version", value="None"), gr.update(value="None", visible=False) 
-    
+            return gr.Dropdown(choices=["None"], interactive=True, label="Model version", value="None"), gr.update(value="None", visible=False)
+
     det_drop.change(update_ui_elements, det_drop, [det_version, clf_drop])
 
     def toggle_textboxes(model):
@@ -281,7 +292,7 @@ with gr.Blocks() as demo:
             return gr.update(visible=True), gr.update(visible=True)
         else:
             return gr.update(visible=False), gr.update(visible=False)
-    
+
     clf_drop.change(
         toggle_textboxes,
         clf_drop,
@@ -294,7 +305,7 @@ with gr.Blocks() as demo:
                 sgl_in = gr.Image(type="pil")
                 sgl_conf_sl_det = gr.Slider(0, 1, label="Detection Confidence Threshold", value=0.2)
                 sgl_conf_sl_clf = gr.Slider(0, 1, label="Classification Confidence Threshold", value=0.7, visible=True)
-            sgl_out = gr.Image() 
+            sgl_out = gr.Image()
         sgl_but = gr.Button("Detect Animals!")
     with gr.Tab("Folder Separation"):
         with gr.Row():
@@ -333,18 +344,43 @@ with gr.Blocks() as demo:
                     )
             vid_out = gr.Video()
         vid_but = gr.Button("Detect Animals!")
-        
+
     # Show timelapsed checkbox only when detection model is not HerdNet
     det_drop.change(
         lambda model: gr.update(visible=True) if "HerdNet" not in model else gr.update(visible=False),
         det_drop,
         [chck_timelapse]
     )
-    
+
     load_but.click(load_models, inputs=[det_drop, det_version, clf_drop, custom_weights_path, custom_weights_class], outputs=load_out)
     sgl_but.click(single_image_detection, inputs=[sgl_in, sgl_conf_sl_det, sgl_conf_sl_clf], outputs=sgl_out)
     bth_but.click(batch_detection, inputs=[bth_in, chck_timelapse, bth_conf_sl], outputs=bth_out)
     vid_but.click(video_detection, inputs=[vid_in, vid_conf_sl_det, vid_conf_sl_clf, vid_fr, vid_enc], outputs=vid_out)
 
 if __name__ == "__main__":
-    demo.launch(share=True)
+    # SECURITY-HARDENED LAUNCH.
+    # - share=False: never open a public gradio.live tunnel from example code.
+    # - server_name/server_port are intentionally omitted so Gradio falls back
+    #   to 127.0.0.1 locally while still honoring GRADIO_SERVER_NAME /
+    #   GRADIO_SERVER_PORT env vars for containerized deployments (see
+    #   Dockerfile). If you set GRADIO_SERVER_NAME=0.0.0.0, make sure the
+    #   listener is only reachable from a trusted network or is behind an
+    #   authenticating reverse proxy.
+    # - allowed_paths restricts the /file= endpoint to the demo's scratch dir.
+    # - blocked_paths is defense-in-depth against known arbitrary-file-read
+    #   CVEs in older Gradio 4.x releases (e.g. CVE-2024-1561, CVE-2024-4941).
+    #   Requires gradio>=4.44.1 for the underlying fixes.
+    demo.launch(
+        share=False,
+        allowed_paths=[TEMP_DIR],
+        blocked_paths=[
+            "/etc",
+            "/root",
+            "/proc",
+            "/sys",
+            os.path.expanduser("~/.ssh"),
+            os.path.expanduser("~/.aws"),
+            os.path.expanduser("~/.azure"),
+            os.path.expanduser("~/.config"),
+        ],
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ torchaudio
 tqdm
 Pillow
 supervision==0.23.0
-gradio
+# SECURITY: gradio<4.44.1 contains arbitrary-file-read CVEs
+# (e.g. CVE-2024-1561, CVE-2024-4941) exploitable via demo/gradio_demo.py.
+gradio>=4.44.1,<5
 chardet
 wget
 ultralytics

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/microsoft/Biodiversity/',
     license='MIT',
     author='Andres Hernandez, Zhongqi Miao, Daniela Ruiz Lopez, Isai Daniel Chacon Silva',
-    author_email='v-hernandres@microsoft.com, zhongqimiao@microsoft.com, v-druizlopez@microsoft.com, v-ichaconsil@microsoft.com',  
+    author_email='v-hernandres@microsoft.com, zhongqimiao@microsoft.com, v-druizlopez@microsoft.com, v-ichaconsil@microsoft.com',
     description='a PyTorch Collaborative Deep Learning Framework for Conservation.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -24,9 +24,12 @@ setup(
         'torchvision',
         'torchaudio',
         'tqdm',
-        'Pillow', 
+        'Pillow',
         'supervision==0.23.0',
-        'gradio',
+        # SECURITY: gradio<4.44.1 contains multiple arbitrary-file-read CVEs
+        # (e.g. CVE-2024-1561, CVE-2024-4941) exploitable via the demo in
+        # demo/gradio_demo.py. Pin to the 4.x line with the fixes applied.
+        'gradio>=4.44.1,<5',
         'ultralytics',
         'chardet',
         'wget',
@@ -39,11 +42,11 @@ setup(
         'setuptools==68.2.2'
     ],
     classifiers=[
-        'Development Status :: 3 - Alpha',  
-        'Intended Audience :: Developers', 
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
     keywords='pytorch_wildlife, pytorch, wildlife, megadetector, conservation, animal, detection, classification',
-    python_requires='>=3.8',
+    python_requires='>=3.10',
 )


### PR DESCRIPTION
**Title:** `fix(security): harden Gradio demo and pin gradio to CVE-fixed line`

Fixes MSRC `119682`: unauthenticated arbitrary file read via `demo/gradio_demo.py`.

Two issues combined: `demo.launch(share=True)` published a public tunnel with no auth, and unpinned `gradio` resolved to a 4.x release with known file-read CVEs (e.g. CVE-2024-1561, CVE-2024-4941) under the documented Python 3.8 install path.

**Changes:**
- `demo/gradio_demo.py`: `share=True` → `share=False`; scratch dir moved from `../temp` to `tempfile.mkdtemp()`; added `allowed_paths` / `blocked_paths` on `launch()`. Container deployments still honor `GRADIO_SERVER_NAME` / `GRADIO_SERVER_PORT`.
<!-- Biodiversity: -->
- `setup.py` / `requirements.txt`: pin `gradio>=4.44.1,<5`; `python_requires='>=3.10'`.
- `Dockerfile`: `python:3.8-slim` → `python:3.11-slim` (3.8 is EOL and caps `gradio` below the fix line).
<!-- Pytorch-Wildlife (use instead of the three lines above): -->
<!-- - `pyproject.toml`: pin `gradio>=4.44.1,<5`; `requires-python = ">=3.10"`; drop 3.8/3.9 classifiers. -->

**Breaking:** Python 3.8/3.9 no longer supported. `share=True` is no longer the default — re-enable locally or front the demo with an auth proxy.

**Validation:** `py_compile` clean