### PR TITLE
Fix #607: support older yolov5 versions lacking scale_boxes

### DIFF
--- a/PytorchWildlife/models/detection/ultralytics_based/yolov5_base.py
+++ b/PytorchWildlife/models/detection/ultralytics_based/yolov5_base.py
@@ -14,7 +14,13 @@ import torch
 from torch.utils.data import DataLoader
 from torch.hub import load_state_dict_from_url
 
-from yolov5.utils.general import non_max_suppression, scale_boxes
+try:
+    from yolov5.utils.general import non_max_suppression, scale_boxes
+except ImportError:
+    # Older yolov5 releases expose this helper as ``scale_coords``; it was
+    # renamed to ``scale_boxes`` in newer versions (same signature). Import it
+    # under the expected name so both versions keep working (see issue #607).
+    from yolov5.utils.general import non_max_suppression, scale_coords as scale_boxes
 from ..base_detector import BaseDetector
 from ....data import transforms as pw_trans
 from ....data import datasets as pw_data


### PR DESCRIPTION
## Summary
`PytorchWildlife/models/detection/ultralytics_based/yolov5_base.py` imported
`scale_boxes` from `yolov5.utils.general`, which raises `ImportError` on older
`yolov5` releases where the helper is named `scale_coords`. Since `yolov5` is an
unpinned dependency (`setup.py`, `requirements.txt`), users can end up with
either name, breaking `import PytorchWildlife`.

## Changes
- Wrapped the import in a `try/except ImportError` that falls back to
  `scale_coords as scale_boxes` (same signature), so both older and newer
  `yolov5` versions work. No dependency changes required.

## Testing
Simulated both a "old" `yolov5` (only `scale_coords`) and a "new" one (with
`scale_boxes`) and confirmed the import resolves `scale_boxes` correctly in both
cases. `py_compile` passes.

Closes #607

## AI assistance
Diagnosis and implementation were done with AI assistance (Claude).