### PR TITLE
fix: resolve open Dependabot alerts

### DIFF
--- a/demo/gradio_demo.py
+++ b/demo/gradio_demo.py
@@ -279,7 +279,7 @@ with gr.Blocks() as demo:
 
     def update_ui_elements(det_model):
         if det_model == "MegaDetectorV6":
-            return gr.Dropdown(choices=["MDV6-yolov9-c", "MDV6-yolov9-e", "MDV6-yolov10-c", "MDV6-yolov10-e", "MDV6-rtdetr-c", "MDV6-yolov9-c-mit", "MDV6-yolov9-e-mit", "MDV6-rtdetr-c-apache", "MDV6-rtdetr-e-apache"], interactive=True, label="Model version", value="MDV6-yolov9e"), gr.update(visible=True)
+            return gr.Dropdown(choices=["MDV6-yolov9-c", "MDV6-yolov9-e", "MDV6-yolov10-c", "MDV6-yolov10-e", "MDV6-rtdetr-c", "MDV6-yolov9-c-mit", "MDV6-yolov9-e-mit", "MDV6-rtdetr-c-apache", "MDV6-rtdetr-e-apache"], interactive=True, label="Model version", value="MDV6-yolov9-e"), gr.update(visible=True)
         elif det_model == "MegaDetectorV5":
             return gr.Dropdown(choices=["a", "b"], interactive=True, label="Model version", value="a"), gr.update(visible=True)
         else:
@@ -369,7 +369,7 @@ if __name__ == "__main__":
     # - allowed_paths restricts the /file= endpoint to the demo's scratch dir.
     # - blocked_paths is defense-in-depth against known arbitrary-file-read
     #   CVEs in older Gradio 4.x releases (e.g. CVE-2024-1561, CVE-2024-4941).
-    #   Requires gradio>=4.44.1 for the underlying fixes.
+    #   The gradio>=6.15.1 dependency floor includes these and later fixes.
     demo.launch(
         share=False,
         allowed_paths=[TEMP_DIR],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ torchaudio
 tqdm
 Pillow
 supervision==0.23.0
-# SECURITY: gradio<4.44.1 contains arbitrary-file-read CVEs
-# (e.g. CVE-2024-1561, CVE-2024-4941) exploitable via demo/gradio_demo.py.
-gradio>=4.44.1,<5
+# SECURITY: Require the patched Gradio 6.x line, including the fix for
+# GHSA-6655-8ph2-63j3 and the earlier arbitrary-file-read advisories.
+gradio>=6.15.1,<7
 chardet
 wget
 ultralytics
 yolov5
-setuptools
+setuptools>=83.0.0
 scikit-learn
 lightning
 omegaconf

--- a/setup.py
+++ b/setup.py
@@ -26,20 +26,18 @@ setup(
         'tqdm',
         'Pillow',
         'supervision==0.23.0',
-        # SECURITY: gradio<4.44.1 contains multiple arbitrary-file-read CVEs
-        # (e.g. CVE-2024-1561, CVE-2024-4941) exploitable via the demo in
-        # demo/gradio_demo.py. Pin to the 4.x line with the fixes applied.
-        'gradio>=4.44.1,<5',
+        # SECURITY: Require the patched Gradio 6.x line, including the fix for
+        # GHSA-6655-8ph2-63j3 and the earlier arbitrary-file-read advisories.
+        'gradio>=6.15.1,<7',
         'ultralytics',
         'chardet',
         'wget',
         'yolov5',
-        'setuptools',
+        'setuptools>=83.0.0',
         'scikit-learn',
         'timm',
         'omegaconf',
-        'lightning',
-        'setuptools==68.2.2'
+        'lightning'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
## Summary
- require Gradio 6.15.1+ to address GHSA-6655-8ph2-63j3 and retain earlier security fixes
- require setuptools 83.0.0+ to address GHSA-h35f-9h28-mq5c, GHSA-5rjg-fvgr-3xxf, and GHSA-cx63-2mw6-8hw5
- remove the duplicate vulnerable setuptools pin
- correct the invalid MegaDetector v6 dropdown default found during Gradio 6 validation

## Validation
- resolved the full requirements set for Python 3.10
- built the source distribution and wheel and inspected dependency metadata
- constructed the demo with Gradio 6.15.1 and the latest allowed 6.x release
- rendered the demo in Chromium with no console, page, or request errors