### PR TITLE
fix: wrap classifier batch inference in torch.no_grad() to stop memory leak

### DIFF
--- a/PytorchWildlife/models/classification/resnet_base/base_classifier.py
+++ b/PytorchWildlife/models/classification/resnet_base/base_classifier.py
@@ -176,15 +176,15 @@ class PlainResNetInference(BaseClassifierInference):
         total_logits = []
         total_paths = []
 
-        with tqdm(total=len(dataloader)) as pbar: 
+        with torch.no_grad(), tqdm(total=len(dataloader)) as pbar:
             for batch in dataloader:
                 imgs, paths = batch
                 imgs = imgs.to(self.device)
-                total_logits.append(self.forward(imgs))
+                total_logits.append(self.forward(imgs).cpu())
                 total_paths.append(paths)
                 pbar.update(1)
 
-        total_logits = torch.cat(total_logits, dim=0).cpu()
+        total_logits = torch.cat(total_logits, dim=0)
         total_paths = np.concatenate(total_paths, axis=0)
 
         return self.results_generation(total_logits, total_paths, id_strip=id_strip)

--- a/PytorchWildlife/models/classification/timm_base/base_classifier.py
+++ b/PytorchWildlife/models/classification/timm_base/base_classifier.py
@@ -196,15 +196,15 @@ class TIMM_BaseClassifierInference(BaseClassifierInference):
         total_logits = []
         total_paths = []
 
-        with tqdm(total=len(dataloader)) as pbar: 
+        with torch.no_grad(), tqdm(total=len(dataloader)) as pbar:
             for batch in dataloader:
                 imgs, paths = batch
                 imgs = imgs.to(self.device)
-                total_logits.append(self.predictor(imgs))
+                total_logits.append(self.predictor(imgs).cpu())
                 total_paths.append(paths)
                 pbar.update(1)
 
-        total_logits = torch.cat(total_logits, dim=0).cpu()
+        total_logits = torch.cat(total_logits, dim=0)
         total_paths = np.concatenate(total_paths, axis=0)
 
         return self.results_generation(total_logits, total_paths, id_strip=id_strip)


### PR DESCRIPTION
## What
`batch_image_classification()` in both classifier families ran the forward pass without `torch.no_grad()`:
- `PytorchWildlife/models/classification/timm_base/base_classifier.py` (DFNE / Deepfaune)
- `PytorchWildlife/models/classification/resnet_base/base_classifier.py` (Amazon / Opossum / Serengeti)

Since gradients were tracked, PyTorch retained the autograd graph for every batch appended to `total_logits`, so memory grew unbounded over a run instead of staying flat.

Also moved each batch's logits to CPU right after inference (`.cpu()` per batch) instead of holding them all on GPU until the final `torch.cat(...).cpu()`, so peak VRAM no longer scales with dataset size.

## Why
Fixes #609 — reported ~300GB RAM/VRAM growth and a crash before completing inference on ~3000 images. Root cause and reproduction were already diagnosed in the issue; this PR applies the same fix to both classifier base classes since they share the identical pattern.

## Testing
Confirmed both loops are functionally unchanged (same batch order, same result construction) — only the gradient-tracking and CPU-transfer timing changed. Verified `python -c "import ast; ast.parse(open(f).read())"` on both files.

Scope kept to the reported bug only (`batch_image_classification`); `single_image_classification` isn't part of the leak (no accumulation across a loop) so left untouched to keep this PR focused.

## Disclosure
Diagnosis and implementation were done with AI assistance (Claude Code), reviewed and submitted by me.

## Are you willing to submit a PR?
Yes — this is it.